### PR TITLE
Add a requests example for JSON, update simpletest

### DIFF
--- a/examples/requests_json.py
+++ b/examples/requests_json.py
@@ -1,4 +1,3 @@
-# adafruit_requests usage with an esp32spi_socket
 import board
 import busio
 from digitalio import DigitalInOut
@@ -30,24 +29,49 @@ print("Connected to", str(esp.ssid, 'utf-8'), "\tRSSI:", esp.rssi)
 
 requests.set_socket(socket, esp)
 
-# Initialize a requests object with a socket and esp32spi interface
-TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
+JSON_URL_GET = "http://httpbin.org/get"
+JSON_URL_POST = "http://httpbin.org/post"
 
-print("Fetching text from %s"%TEXT_URL)
-response = requests.get(TEXT_URL)
+# Custom Header
+headers = {"user-agent" : "blinka/1.0.0"}
+
+print("Fetching JSON from %s"%JSON_URL_GET)
+response = requests.get(JSON_URL_GET, headers=headers)
 print('-'*40)
 
-print("Text Response: ", response.text)
+json_data = response.json()
+print("JSON Response: ", json_data)
 print('-'*40)
 
-print("Raw Response, as bytes: {0}".format(response.content))
+headers = json_data['headers']
+print("Returned Custom User-Agent Header: {0}".format(headers['User-Agent']))
+print('-'*40)
+# Close, delete and collect the response data
+response.close()
+
+# Let's POST some data!
+
+print("Posting data to %s..."%JSON_URL_POST)
+response = requests.post(JSON_URL_POST, data="hello server!")
 print('-'*40)
 
-print("Response's HTTP Status Code: %d"%response.status_code)
+json_data = response.json()
+print("JSON Response: ", json_data)
+print('-'*40)
+print("Data Returned: ", json_data['data'])
+print('-'*40)
+# Close, delete and collect the response data
+response.close()
+
+# Let's post some JSON data!
+print("Posting JSON data to %s..."%JSON_URL_POST)
+response = requests.post(JSON_URL_POST, json={"date" : "Jul 25, 2019"})
 print('-'*40)
 
-print("Response's HTTP Headers: %s"%response.headers)
+json_data = response.json()
+print("JSON Response: ", json_data)
 print('-'*40)
-
+print("JSON Data Returned: ", json_data['json'])
+print('-'*40)
 # Close, delete and collect the response data
 response.close()

--- a/examples/requests_simpletest.py
+++ b/examples/requests_simpletest.py
@@ -6,12 +6,6 @@ import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 from adafruit_esp32spi import adafruit_esp32spi
 import adafruit_requests as requests
 
-print("ESP32 SPI webclient test")
-
-TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
-JSON_URL = "http://api.coindesk.com/v1/bpi/currentprice/USD.json"
-
-
 # If you are using a board with pre-defined ESP32 Pins:
 esp32_cs = DigitalInOut(board.ESP_CS)
 esp32_ready = DigitalInOut(board.ESP_BUSY)
@@ -24,7 +18,6 @@ esp32_reset = DigitalInOut(board.ESP_RESET)
 
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-requests.set_socket(socket, esp)
 
 print("Connecting to AP...")
 while not esp.is_connected:
@@ -35,20 +28,26 @@ while not esp.is_connected:
         continue
 print("Connected to", str(esp.ssid, 'utf-8'), "\tRSSI:", esp.rssi)
 
-#esp._debug = True
-print("Fetching text from", TEXT_URL)
-r = requests.get(TEXT_URL)
-print('-'*40)
-print(r.text)
-print('-'*40)
-r.close()
+requests.set_socket(socket, esp)
 
-print()
-print("Fetching json from", JSON_URL)
-r = requests.get(JSON_URL)
-print('-'*40)
-print(r.json())
-print('-'*40)
-r.close()
+# Initialize a requests object with a socket and esp32spi interface
+TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
 
-print("Done!")
+print("Fetching text from %s"%TEXT_URL)
+response = requests.get(TEXT_URL)
+print('-'*40)
+
+print("Text Response: ", response.text)
+print('-'*40)
+
+print("Raw Response, as bytes: {0}".format(response.content))
+print('-'*40)
+
+print("Response's HTTP Status Code: %d"%response.status_code)
+print('-'*40)
+
+print("Response's HTTP Headers: %s"%response.headers)
+print('-'*40)
+
+# Close, delete and collect the response data
+response.close()


### PR DESCRIPTION
Adding a more advanced example `requests_json.py` to demonstrate commonly-used requests functionality such as setting custom headers, sending data, sending json data, and parsing data from a response.

Updates simpletest to show automatically-decoded text response, the raw response (as bytes), the response's HTTP status code, and response's HTTP headers.