### PR TITLE
Add Parse_Headers Method Back

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -250,10 +250,26 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
     resp.reason = reason
     return resp
 
+def parse_headers(sock):
+    """
+    Parses the header portion of an HTTP request/response from the socket.
+    Expects first line of HTTP request/response to have been read already
+    return: header dictionary
+    rtype: Dict
+    """
+    headers = {}
+    while True:
+        line = sock.readline()
+        if not line or line == b"\r\n":
+            break
 
-# pylint: enable=too-many-branches, too-many-statements, unused-argument
-# pylint: enable=too-many-arguments, too-many-locals
-
+        #print("**line: ", line)
+        title, content = line.split(b': ', 1)
+        if title and content:
+            title = str(title.lower(), 'utf-8')
+            content = str(content, 'utf-8')
+            headers[title] = content
+    return headers
 
 def head(url, **kw):
     """Send HTTP HEAD request"""


### PR DESCRIPTION
Adding `parse_headers` back from ESP32SPI_Requests.

Re, issue: https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/issues/62

Code Output
```
code.py output:
ESP32 SPI simple web server test!
soft reboot

Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
ESP32 SPI simple web server test!
open this IP in your browser:  10.0.0.208
```