### PR TITLE
Refactor request method to use parse_headers

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -224,7 +224,7 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
         reason = ""
         if len(line) > 2:
             reason = line[2].rstrip()
-        self.parse_headers(sock)
+        parse_headers(sock)
 
         if line.startswith(b"Transfer-Encoding:"):
             if b"chunked" in line:

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -224,12 +224,11 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
         reason = ""
         if len(line) > 2:
             reason = line[2].rstrip()
-        parse_headers(sock)
-
-        if line.startswith(b"Transfer-Encoding:"):
-            if b"chunked" in line:
-                raise ValueError("Unsupported " + line)
-        elif line.startswith(b"Location:") and not 200 <= status <= 299:
+        resp.headers = parse_headers(sock)
+        if resp.headers.get("transfer-encoding"):
+            if "chunked" in resp.headers.get("transfer-encoding"):
+                raise ValueError("Unsupported " + str(line[0]))
+        elif resp.headers.get("location") and not 200 <= status <= 299:
             raise NotImplementedError("Redirects not yet supported")
 
     except:

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -227,7 +227,7 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
         resp.headers = parse_headers(sock)
         if resp.headers.get("transfer-encoding"):
             if "chunked" in resp.headers.get("transfer-encoding"):
-                raise ValueError("Unsupported " + str(line[0]))
+                raise ValueError("Unsupported " + resp.headers.get("transfer-encoding"))
         elif resp.headers.get("location") and not 200 <= status <= 299:
             raise NotImplementedError("Redirects not yet supported")
 

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -224,23 +224,13 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
         reason = ""
         if len(line) > 2:
             reason = line[2].rstrip()
-        while True:
-            line = sock.readline()
-            if not line or line == b"\r\n":
-                break
+        self.parse_headers(sock)
 
-            # print("**line: ", line)
-            title, content = line.split(b": ", 1)
-            if title and content:
-                title = str(title.lower(), "utf-8")
-                content = str(content, "utf-8")
-                resp.headers[title] = content
-
-            if line.startswith(b"Transfer-Encoding:"):
-                if b"chunked" in line:
-                    raise ValueError("Unsupported " + line)
-            elif line.startswith(b"Location:") and not 200 <= status <= 299:
-                raise NotImplementedError("Redirects not yet supported")
+        if line.startswith(b"Transfer-Encoding:"):
+            if b"chunked" in line:
+                raise ValueError("Unsupported " + line)
+        elif line.startswith(b"Location:") and not 200 <= status <= 299:
+            raise NotImplementedError("Redirects not yet supported")
 
     except:
         sock.close()


### PR DESCRIPTION
Addressing https://github.com/adafruit/Adafruit_CircuitPython_Requests/issues/6

Request now uses `parse_headers`. 

Tested with `WSGIServer.py` on Adafruit CircuitPython 4.0.0 on 2019-05-20; Adafruit PyPortal with samd51j20.
https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/blob/master/examples/server/esp32spi_wsgiserver.py