### PR TITLE
If data is dictionary send it as form data

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -212,7 +212,7 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
             data = json_module.dumps(json)
             sock.send(b"Content-Type: application/json\r\n")
         if data:
-            if type(data) is dict:
+            if isinstance(data, dict):
                 sock.send(b"Content-Type: application/x-www-form-urlencoded\r\n")
                 _post_data = ""
                 for k in data:

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -146,7 +146,7 @@ class Response:
 
 
 # pylint: disable=too-many-branches, too-many-statements, unused-argument, too-many-arguments, too-many-locals
-def request(method, url, data=None, json=None, headers=None, stream=False, timeout=1):
+def request(method, url, data=None, json=None, headers=None, stream=False, timeout=1, content_type=None):
     """Perform an HTTP request to the given url which we will parse to determine
     whether to use SSL ('https://') or not. We can also send some provided 'data'
     or a json dictionary which we will stringify. 'headers' is optional HTTP headers
@@ -212,6 +212,8 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
             data = json_module.dumps(json)
             sock.send(b"Content-Type: application/json\r\n")
         if data:
+            if content_type is not None:
+                sock.send(b"Content-Type: %s\r\n" % content_type)
             sock.send(b"Content-Length: %d\r\n" % len(data))
         sock.send(b"\r\n")
         if data:

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -146,7 +146,7 @@ class Response:
 
 
 # pylint: disable=too-many-branches, too-many-statements, unused-argument, too-many-arguments, too-many-locals
-def request(method, url, data=None, json=None, headers=None, stream=False, timeout=1, content_type=None):
+def request(method, url, data=None, json=None, headers=None, stream=False, timeout=1):
     """Perform an HTTP request to the given url which we will parse to determine
     whether to use SSL ('https://') or not. We can also send some provided 'data'
     or a json dictionary which we will stringify. 'headers' is optional HTTP headers
@@ -212,8 +212,6 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
             data = json_module.dumps(json)
             sock.send(b"Content-Type: application/json\r\n")
         if data:
-            if content_type is not None:
-                sock.send(b"Content-Type: %s\r\n" % content_type)
             sock.send(b"Content-Length: %d\r\n" % len(data))
         sock.send(b"\r\n")
         if data:

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -212,6 +212,12 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
             data = json_module.dumps(json)
             sock.send(b"Content-Type: application/json\r\n")
         if data:
+            if type(data) is dict:
+                sock.send(b"Content-Type: application/x-www-form-urlencoded\r\n")
+                _post_data = ""
+                for k in data:
+                    _post_data = "{}&{}={}".format(_post_data, k, data[k])
+                data = _post_data[1:]
             sock.send(b"Content-Length: %d\r\n" % len(data))
         sock.send(b"\r\n")
         if data:


### PR DESCRIPTION
In python3 with requests we can use code like this: 
```
import requests
URL = "https://docs.google.com/forms/u/0/d/e/1FAIpQLScoUhFA1BIJjXF2-QM_mxNMN62Y2BCJ--gwJIwWcwJPvWDlwQ/formResponse"
form_data = {
    "entry.2004206042": "Hello",
    "entry.487209416": "Binka"
}
r = requests.post(URL, data=form_data)
print(r.text)
```
And the data will get sent as form data. More specifically using the format:
`name=value&other_name=other_value`

and gets sent using `Content-Type: application/x-www-form-urlencoded`

This allows us to use a simple dictionary for our form data but submit it to web apps expecting data from an html `<form>` element. 

This change allows the circuitpython requests library to behave similarly. When `data` is a dictionary it will get formatted into the key/value string and sent with `Content-Type: application/x-www-form-urlencoded`

With this change we can use almost the same code for python3 and CircuitPython to post data to Google forms/spreadsheets and and similar `<form>` based web apps. 