### PR TITLE
Removed encoding parameter from bytes call

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -221,7 +221,10 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
             sock.send(b"Content-Length: %d\r\n" % len(data))
         sock.send(b"\r\n")
         if data:
-            sock.send(bytes(data))
+            if isinstance(data, bytearray):
+                sock.send(bytes(data))
+            else:
+                sock.send(bytes(data, "utf-8"))
 
         line = sock.readline()
         # print(line)

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -221,7 +221,7 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
             sock.send(b"Content-Length: %d\r\n" % len(data))
         sock.send(b"\r\n")
         if data:
-            sock.send(bytes(data, "utf-8"))
+            sock.send(bytes(data))
 
         line = sock.readline()
         # print(line)


### PR DESCRIPTION
As dicsussed in #20, the encoding parameter passed to the `byes` call gives a **TypeError: wrong number of arguments**