### PR TITLE
Add Simpletest for Ethernet Library

### DIFF
--- a/examples/requests_advanced_ethernet.py
+++ b/examples/requests_advanced_ethernet.py
@@ -27,7 +27,7 @@ print("Fetching JSON data from %s..."%JSON_GET_URL)
 while not response:
     try:
         response = requests.get(JSON_GET_URL, headers=headers)
-        attempts = 0
+        failure_count = 0
     except AssertionError as error:
         print("Request failed, retrying...\n", error)
         failure_count += 1

--- a/examples/requests_advanced_ethernet.py
+++ b/examples/requests_advanced_ethernet.py
@@ -1,0 +1,39 @@
+import board
+import busio
+from digitalio import DigitalInOut
+from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
+import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
+import adafruit_requests as requests
+
+cs = DigitalInOut(board.D10)
+spi_bus = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+
+# Initialize ethernet interface with DHCP
+eth = WIZNET5K(spi_bus, cs)
+
+# Initialize a requests object with a socket and ethernet interface
+requests.set_socket(socket, eth)
+
+JSON_GET_URL = "http://httpbin.org/get"
+
+# Define a custom header as a dict.
+headers = {"user-agent" : "blinka/1.0.0"}
+
+print("Fetching JSON data from %s..."%JSON_GET_URL)
+response = requests.get(JSON_GET_URL, headers=headers)
+print('-'*60)
+
+json_data = response.json()
+headers = json_data['headers']
+print("Response's Custom User-Agent Header: {0}".format(headers['User-Agent']))
+print('-'*60)
+
+# Read Response's HTTP status code
+print("Response HTTP Status Code: ", response.status_code)
+print('-'*60)
+
+# Read Response, as raw bytes instead of pretty text
+print("Raw Response: ", response.content)
+
+# Close, delete and collect the response data
+response.close()

--- a/examples/requests_advanced_ethernet.py
+++ b/examples/requests_advanced_ethernet.py
@@ -16,11 +16,25 @@ requests.set_socket(socket, eth)
 
 JSON_GET_URL = "http://httpbin.org/get"
 
+attempts = 3 # Number of attempts to retry each request
+failure_count = 0
+response = None
+
 # Define a custom header as a dict.
 headers = {"user-agent" : "blinka/1.0.0"}
 
 print("Fetching JSON data from %s..."%JSON_GET_URL)
-response = requests.get(JSON_GET_URL, headers=headers)
+while not response:
+    try:
+        response = requests.get(JSON_GET_URL, headers=headers)
+        attempts = 0
+    except AssertionError as error:
+        print("Request failed, retrying...\n", error)
+        failure_count += 1
+        if failure_count >= attempts:
+            raise AssertionError("Failed to resolve hostname, \
+                                  please check your router's DNS configuration.")
+        continue
 print('-'*60)
 
 json_data = response.json()

--- a/examples/requests_simpletest_ethernet.py
+++ b/examples/requests_simpletest_ethernet.py
@@ -1,0 +1,57 @@
+import board
+import busio
+from digitalio import DigitalInOut
+from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
+import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
+import adafruit_requests as requests
+
+cs = DigitalInOut(board.D10)
+spi_bus = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+
+# Initialize ethernet interface with DHCP
+eth = WIZNET5K(spi_bus, cs)
+
+# Initialize a requests object with a socket and ethernet interface
+requests.set_socket(socket, eth)
+
+TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
+JSON_GET_URL = "http://httpbin.org/get"
+JSON_POST_URL = "http://httpbin.org/post"
+
+print("Fetching text from %s"%TEXT_URL)
+response = requests.get(TEXT_URL)
+print('-'*40)
+
+print("Text Response: ", response.text)
+print('-'*40)
+response.close()
+
+print("Fetching JSON data from %s"%JSON_GET_URL)
+response = requests.get(JSON_GET_URL)
+print('-'*40)
+
+print("JSON Response: ", response.json())
+print('-'*40)
+response.close()
+
+data = '31F'
+print("POSTing data to {0}: {1}".format(JSON_POST_URL, data))
+response = requests.post(JSON_POST_URL, data=data)
+print('-'*40)
+
+json_resp = response.json()
+# Parse out the 'data' key from json_resp dict.
+print("Data received from server:", json_resp['data'])
+print('-'*40)
+response.close()
+
+json_data = {"Date" : "July 25, 2019"}
+print("POSTing data to {0}: {1}".format(JSON_POST_URL, json_data))
+response = requests.post(JSON_POST_URL, json=json_data)
+print('-'*40)
+
+json_resp = response.json()
+# Parse out the 'json' key from json_resp dict.
+print("JSON Data received from server:", json_resp['json'])
+print('-'*40)
+response.close()

--- a/examples/requests_simpletest_ethernet.py
+++ b/examples/requests_simpletest_ethernet.py
@@ -18,25 +18,61 @@ TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
 JSON_GET_URL = "http://httpbin.org/get"
 JSON_POST_URL = "http://httpbin.org/post"
 
+attempts = 3 # Number of attempts to retry each request
+failure_count = 0
+response = None
+
 print("Fetching text from %s"%TEXT_URL)
-response = requests.get(TEXT_URL)
+while not response:
+    try:
+        response = requests.get(TEXT_URL)
+        attempts = 0
+    except AssertionError as error:
+        print("Request failed, retrying...\n", error)
+        failure_count += 1
+        if failure_count >= attempts:
+            raise AssertionError("Failed to resolve hostname, \
+                                  please check your router's DNS configuration.")
+        continue
 print('-'*40)
 
 print("Text Response: ", response.text)
 print('-'*40)
 response.close()
+response = None
 
 print("Fetching JSON data from %s"%JSON_GET_URL)
-response = requests.get(JSON_GET_URL)
+while not response:
+    try:
+        response = requests.get(JSON_GET_URL)
+        attempts = 0
+    except AssertionError as error:
+        print("Request failed, retrying...\n", error)
+        failure_count += 1
+        if failure_count >= attempts:
+            raise AssertionError("Failed to resolve hostname, \
+                                  please check your router's DNS configuration.")
+        continue
 print('-'*40)
 
 print("JSON Response: ", response.json())
 print('-'*40)
 response.close()
+response = None
 
 data = '31F'
 print("POSTing data to {0}: {1}".format(JSON_POST_URL, data))
-response = requests.post(JSON_POST_URL, data=data)
+while not response:
+    try:
+        response = requests.post(JSON_POST_URL, data=data)
+        attempts = 0
+    except AssertionError as error:
+        print("Request failed, retrying...\n", error)
+        failure_count += 1
+        if failure_count >= attempts:
+            raise AssertionError("Failed to resolve hostname, \
+                                  please check your router's DNS configuration.")
+        continue
 print('-'*40)
 
 json_resp = response.json()
@@ -44,10 +80,21 @@ json_resp = response.json()
 print("Data received from server:", json_resp['data'])
 print('-'*40)
 response.close()
+response = None
 
 json_data = {"Date" : "July 25, 2019"}
 print("POSTing data to {0}: {1}".format(JSON_POST_URL, json_data))
-response = requests.post(JSON_POST_URL, json=json_data)
+while not response:
+    try:
+        response = requests.post(JSON_POST_URL, json=json_data)
+        attempts = 0
+    except AssertionError as error:
+        print("Request failed, retrying...\n", error)
+        failure_count += 1
+        if failure_count >= attempts:
+            raise AssertionError("Failed to resolve hostname, \
+                                  please check your router's DNS configuration.")
+        continue
 print('-'*40)
 
 json_resp = response.json()

--- a/examples/requests_simpletest_ethernet.py
+++ b/examples/requests_simpletest_ethernet.py
@@ -26,7 +26,7 @@ print("Fetching text from %s"%TEXT_URL)
 while not response:
     try:
         response = requests.get(TEXT_URL)
-        attempts = 0
+        failure_count = 0
     except AssertionError as error:
         print("Request failed, retrying...\n", error)
         failure_count += 1
@@ -45,7 +45,7 @@ print("Fetching JSON data from %s"%JSON_GET_URL)
 while not response:
     try:
         response = requests.get(JSON_GET_URL)
-        attempts = 0
+        failure_count = 0
     except AssertionError as error:
         print("Request failed, retrying...\n", error)
         failure_count += 1
@@ -65,7 +65,7 @@ print("POSTing data to {0}: {1}".format(JSON_POST_URL, data))
 while not response:
     try:
         response = requests.post(JSON_POST_URL, data=data)
-        attempts = 0
+        failure_count = 0
     except AssertionError as error:
         print("Request failed, retrying...\n", error)
         failure_count += 1
@@ -87,7 +87,7 @@ print("POSTing data to {0}: {1}".format(JSON_POST_URL, json_data))
 while not response:
     try:
         response = requests.post(JSON_POST_URL, json=json_data)
-        attempts = 0
+        failure_count = 0
     except AssertionError as error:
         print("Request failed, retrying...\n", error)
         failure_count += 1


### PR DESCRIPTION
Adding a simpletest for the ethernet library. This will be used in a future Learning System Guide.

Requires: https://github.com/adafruit/Adafruit_CircuitPython_Wiznet5k/pull/7

Tested on:  `Adafruit CircuitPython 5.0.0 on 2020-03-02; Adafruit Metro M4 Express with samd51j19`

Test output:
```
code.py output:
Fetching text from http://wifitest.adafruit.com/testwifi/index.html
----------------------------------------
Text Response:  This is a test of Adafruit WiFi!
If you can read this, its working :)

----------------------------------------
Fetching JSON data from http://httpbin.org/get
----------------------------------------
JSON Response:  {'url': 'http://httpbin.org/get', 'headers': {'User-Agent': 'Adafruit CircuitPython', 'Host': 'httpbin.org', 'X-Amzn-Trace-Id': 'Root=1-5e627b53-b98194cf883dda881877943c'}, 'args': {}, 'origin': '73.38.253.75'}
----------------------------------------
POSTing data to http://httpbin.org/post: 31F
----------------------------------------
Data received from server: 31F
----------------------------------------
POSTing data to http://httpbin.org/post: {'Date': 'July 25, 2019'}
----------------------------------------
JSON Data received from server: {'Date': 'July 25, 2019'}
----------------------------------------
```