### PR TITLE
Update Cellular Examples for Adafruit FONA (3G/GSM)

### DIFF
--- a/examples/requests_advanced.py
+++ b/examples/requests_advanced.py
@@ -1,49 +1,34 @@
-# pylint: disable=unused-import
-import time
 import board
 import busio
-import digitalio
-from adafruit_fona.adafruit_fona import FONA
-from adafruit_fona.fona_3g import FONA3G
-import adafruit_fona.adafruit_fona_network as network
-import adafruit_fona.adafruit_fona_socket as cellular_socket
+from digitalio import DigitalInOut
+import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+from adafruit_esp32spi import adafruit_esp32spi
 import adafruit_requests as requests
 
-# Get GPRS details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("GPRS secrets are kept in secrets.py, please add them there!")
-    raise
+# If you are using a board with pre-defined ESP32 Pins:
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 
-# Create a serial connection for the FONA connection
-uart = busio.UART(board.TX, board.RX)
-rst = digitalio.DigitalInOut(board.D9)
+# If you have an externally connected ESP32:
+# esp32_cs = DigitalInOut(board.D9)
+# esp32_ready = DigitalInOut(board.D10)
+# esp32_reset = DigitalInOut(board.D5)
 
-# Use this for FONA800 and FONA808
-fona = FONA(uart, rst)
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 
-# Use this for FONA3G
-# fona = FONA3G(uart, rst)
+print("Connecting to AP...")
+while not esp.is_connected:
+    try:
+        esp.connect_AP(b"MY_SSID_NAME", b"MY_SSID_PASSWORD")
+    except RuntimeError as e:
+        print("could not connect to AP, retrying: ", e)
+        continue
+print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
 
-# Initialize cellular data network
-network = network.CELLULAR(
-    fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"])
-)
-
-while not network.is_attached:
-    print("Attaching to network...")
-    time.sleep(0.5)
-print("Attached!")
-
-while not network.is_connected:
-    print("Connecting to network...")
-    network.connect()
-    time.sleep(0.5)
-print("Network Connected!")
-
-# Initialize a requests object with a socket and cellular interface
-requests.set_socket(cellular_socket, fona)
+# Initialize a requests object with a socket and esp32spi interface
+requests.set_socket(socket, esp)
 
 JSON_GET_URL = "http://httpbin.org/get"
 

--- a/examples/requests_advanced_cellular.py
+++ b/examples/requests_advanced_cellular.py
@@ -1,9 +1,11 @@
+# pylint: disable=unused-import
 import time
 import board
 import busio
 import digitalio
 from adafruit_fona.adafruit_fona import FONA
-from adafruit_fona.adafruit_fona_gsm import GSM
+from adafruit_fona.fona_3g import FONA3G
+import adafruit_fona.adafruit_fona_network as network
 import adafruit_fona.adafruit_fona_socket as cellular_socket
 import adafruit_requests as requests
 
@@ -14,26 +16,31 @@ except ImportError:
     print("GPRS secrets are kept in secrets.py, please add them there!")
     raise
 
-# Create a serial connection for the FONA connection using 4800 baud.
-# These are the defaults you should use for the FONA Shield.
-# For other boards set RX = GPS module TX, and TX = GPS module RX pins.
-uart = busio.UART(board.TX, board.RX, baudrate=4800)
-rst = digitalio.DigitalInOut(board.D4)
+# Create a serial connection for the FONA connection
+uart = busio.UART(board.TX, board.RX)
+rst = digitalio.DigitalInOut(board.D9)
 
-# Initialize FONA module (this may take a few seconds)
-fona = FONA(uart, rst)
+# Use this for FONA800 and FONA808
+# fona = FONA(uart, rst)
 
-# initialize gsm
-gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
+# Use this for FONA3G
+fona = FONA3G(uart, rst)
 
-while not gsm.is_attached:
+# Initialize cellular data network
+network = network.CELLULAR(
+    fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"])
+)
+
+while not network.is_attached:
     print("Attaching to network...")
     time.sleep(0.5)
+print("Attached!")
 
-while not gsm.is_connected:
+while not network.is_connected:
     print("Connecting to network...")
-    gsm.connect()
-    time.sleep(5)
+    network.connect()
+    time.sleep(0.5)
+print("Network Connected!")
 
 # Initialize a requests object with a socket and cellular interface
 requests.set_socket(cellular_socket, fona)


### PR DESCRIPTION
Updating Cellular examples for Adafruit Fona v2.0.0
https://github.com/adafruit/Adafruit_CircuitPython_FONA

--- 
### Tests

#### FONA808

`examples/requests_advanced_cellular.py`
```
code.py output:
Attaching to network...
Attaching to network...
Attaching to network...
Attached!
Connecting to network...
Network Connected!
Fetching JSON data from http://httpbin.org/get...
------------------------------------------------------------
Response's Custom User-Agent Header: Adafruit CircuitPython,blinka/1.0.0
------------------------------------------------------------
Response HTTP Status Code:  200
------------------------------------------------------------
Raw Response:  b'{\n  "args": {}, \n  "headers": {\n    "Host": "httpbin.org", \n    "User-Agent": "Adafruit CircuitPython,blinka/1.0.0", \n    "X-Amzn-Trace-Id": "Root=1-5ed55a7a-971197216b39495592d6b928"\n  }, \n  "origin": "172.58.230.203", \n  "url": "http://httpbin.org/get"\n}\n'
```

`examples/requests_simpletest_cellular.py`
```
code.py output:
Attaching to network...
Attaching to network...
Attaching to network...
Attached!
Connecting to network...
Network Connected!
Fetching text from http://wifitest.adafruit.com/testwifi/index.html
----------------------------------------
Text Response:  This is a test of Adafruit WiFi!
If you can read this, its working :)

----------------------------------------
Fetching JSON data from http://httpbin.org/get
----------------------------------------
JSON Response:  {'url': 'http://httpbin.org/get', 'headers': {'User-Agent': 'Adafruit CircuitPython', 'Host': 'httpbin.org', 'X-Amzn-Trace-Id': 'Root=1-5ed5599c-3fc3b9e0c88b9b9c6401c2f0'}, 'args': {}, 'origin': '172.58.219.124'}
----------------------------------------
POSTing data to http://httpbin.org/post: 31F
----------------------------------------
Data received from server: 31F
----------------------------------------
POSTing data to http://httpbin.org/post: {'Date': 'July 25, 2019'}
----------------------------------------
JSON Data received from server: {'Date': 'July 25, 2019'}
----------------------------------------
```



#### FONA3G
`examples/requests_advanced_cellular.py`
```
code.py output:
Attaching to network...
...
Attached!
Connecting to network...
Network Connected!
Fetching JSON data from http://httpbin.org/get...
------------------------------------------------------------
Response's Custom User-Agent Header: Adafruit CircuitPython,blinka/1.0.0
------------------------------------------------------------
Response HTTP Status Code:  200
------------------------------------------------------------
Raw Response:  b'{\n  "args": {}, \n  "headers": {\n    "Host": "httpbin.org", \n    "User-Agent": "Adafruit CircuitPython,blinka/1.0.0", \n    "X-Amzn-Trace-Id": "Root=1-5ed56081-59b25ec0b38383f42de98e28"\n  }, \n  "origin": "172.58.235.142", \n  "url": "http://httpbin.org/get"\n}\n'
```

`requests_simpletest_cellular.py`
```
code.py output:
Attaching to network...
...
Attaching to network...
Attached!
Connecting to network...
Connecting to network...
Network Connected!
Fetching text from http://wifitest.adafruit.com/testwifi/index.html
----------------------------------------
Text Response:  This is a test of Adafruit WiFi!
If you can read this, its working :)

----------------------------------------
Fetching JSON data from http://httpbin.org/get
----------------------------------------
JSON Response:  {'url': 'http://httpbin.org/get', 'headers': {'User-Agent': 'Adafruit CircuitPython', 'Host': 'httpbin.org', 'X-Amzn-Trace-Id': 'Root=1-5ed5626f-4e8e8a8366aeb608051d33c4'}, 'args': {}, 'origin': '172.58.235.22'}
----------------------------------------
POSTing data to http://httpbin.org/post: 31F
----------------------------------------
Data received from server: 31F
----------------------------------------
POSTing data to http://httpbin.org/post: {'Date': 'July 25, 2019'}
----------------------------------------
JSON Data received from server: {'Date': 'July 25, 2019'}
----------------------------------------
```
