### PR TITLE
Add HTTP1.1 support and socket reuse

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -1,6 +1,7 @@
 # The MIT License (MIT)
 #
 # Copyright (c) 2019 ladyada for Adafruit Industries
+# Copyright (c) 2020 Scott Shawcroft for Adafruit Industries
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +27,7 @@
 A requests-like library for web interfacing
 
 
-* Author(s): ladyada, Paul Sokolovsky
+* Author(s): ladyada, Paul Sokolovsky, Scott Shawcroft
 
 Implementation Notes
 --------------------
@@ -377,7 +378,6 @@ class Session:
             raise RuntimeError("Socket not from session")
         self._socket_free[socket] = True
 
-
     def _get_socket(self, host, port, proto, *, timeout=1):
         key = (host, port, proto)
         if key in self._open_sockets:
@@ -524,3 +524,50 @@ class Session:
     def delete(self, url, **kw):
         """Send HTTP DELETE request"""
         return self.request("DELETE", url, **kw)
+
+# Backwards compatible API:
+
+_default_session = None
+
+class FakeSSLContext:
+    def wrap_socket(self, socket):
+        return socket
+
+def set_socket(sock, iface=None):
+    global _default_session
+    _default_session = Session(sock, FakeSSLContext())
+    if iface:
+        sock.set_interface(iface)
+
+def request(method, url, data=None, json=None, headers=None, stream=False, timeout=1):
+    _default_session.request(method, url, data=data, json=json, headers=headers, stream=stream, timeout=timeout)
+
+
+def head(url, **kw):
+    """Send HTTP HEAD request"""
+    return _default_session.request("HEAD", url, **kw)
+
+
+def get(url, **kw):
+    """Send HTTP GET request"""
+    return _default_session.request("GET", url, **kw)
+
+
+def post(url, **kw):
+    """Send HTTP POST request"""
+    return _default_session.request("POST", url, **kw)
+
+
+def put(url, **kw):
+    """Send HTTP PUT request"""
+    return _default_session.request("PUT", url, **kw)
+
+
+def patch(url, **kw):
+    """Send HTTP PATCH request"""
+    return _default_session.request("PATCH", url, **kw)
+
+
+def delete(url, **kw):
+    """Send HTTP DELETE request"""
+    return _default_session.request("DELETE", url, **kw)

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -61,20 +61,21 @@ class _RawResponse:
     def read(self, size=-1):
         """Read as much as available or up to size and return it in a byte string.
 
-           Do NOT use this unless you really need to. Reusing memory with `readinto` is much better.
-           """
+        Do NOT use this unless you really need to. Reusing memory with `readinto` is much better.
+        """
         if size == -1:
             return self._response.content
         return self._response.socket.recv(size)
 
     def readinto(self, buf):
         """Read as much as available into buf or until it is full. Returns the number of bytes read
-           into buf."""
-        return self._response._readinto(buf) # pylint: disable=protected-access
+        into buf."""
+        return self._response._readinto(buf)  # pylint: disable=protected-access
 
 
 class Response:
     """The response from a request, contains all the headers/content"""
+
     # pylint: disable=too-many-instance-attributes
 
     encoding = None
@@ -242,7 +243,7 @@ class Response:
                     self._throw_away(chunk_size + 2)
                 self._parse_headers()
         if self._session:
-            self._session._free_socket(self.socket) # pylint: disable=protected-access
+            self._session._free_socket(self.socket)  # pylint: disable=protected-access
         else:
             self.socket.close()
         self.socket = None
@@ -344,6 +345,7 @@ class Response:
 
 class Session:
     """HTTP session that shares sockets and ssl context."""
+
     def __init__(self, socket_pool, ssl_context=None):
         self._socket_pool = socket_pool
         self._ssl_context = ssl_context
@@ -521,7 +523,7 @@ class Session:
 
 # Backwards compatible API:
 
-_default_session = None # pylint: disable=invalid-name
+_default_session = None  # pylint: disable=invalid-name
 
 
 class _FakeSSLContext:
@@ -534,7 +536,7 @@ class _FakeSSLContext:
 
 def set_socket(sock, iface=None):
     """Legacy API for setting the socket and network interface. Use a `Session` instead."""
-    global _default_session # pylint: disable=global-statement,invalid-name
+    global _default_session  # pylint: disable=global-statement,invalid-name
     _default_session = Session(sock, _FakeSSLContext())
     if iface:
         sock.set_interface(iface)

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -68,7 +68,7 @@ def set_socket(socket):
     _socket = socket
 
 # Hang onto open sockets so that we can reuse them.
-_socket_pool = {}
+_socket_pool = {} # pylint: disable=invalid-name
 def _get_socket(host, port, proto, *, timeout=1):
     key = (host, port, proto)
     if key in _socket_pool:
@@ -169,6 +169,10 @@ class Response:
 
     @property
     def headers(self):
+        """
+        The response headers. Does not include headers from the trailer until
+        the content has been read.
+        """
         return self._headers
 
     @property
@@ -272,9 +276,6 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
     sent along. 'stream' will determine if we buffer everything, or whether to only
     read only when requested
     """
-    global _the_interface  # pylint: disable=global-statement, invalid-name
-    global _socket  # pylint: disable=global-statement, invalid-name
-
     if not headers:
         headers = {}
 
@@ -310,6 +311,7 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
         socket.send(b"\r\n")
     if json is not None:
         assert data is None
+        # pylint: disable=import-outside-toplevel
         try:
             import json as json_module
         except ImportError:

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -537,6 +537,7 @@ class _FakeSSLSocket:
         self.recv = socket.recv
 
     def connect(self, address):
+        """connect wrapper to add non-standard mode parameter"""
         return self._socket.connect(address, self._mode)
 
 

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -54,30 +54,18 @@ import gc
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Requests.git"
 
-# This module mirror CPython's socket class. It is settable because the network devices are external
-# to CircuitPython.
-socket_module = None  # pylint: disable=invalid-name
-ssl_context = None
+class _RawResponse:
+    def __init__(self, response):
+        self._response = response
 
-# Hang onto open sockets so that we can reuse them.
-_socket_pool = {} # pylint: disable=invalid-name
-def _get_socket(host, port, proto, *, timeout=1):
-    key = (host, port, proto)
-    if key in _socket_pool:
-        return _socket_pool[key]
-    if not socket_module:
-        raise RuntimeError("socket_module must be set before using adafruit_requests")
-    if proto == "https:" and not ssl_context:
-        raise RuntimeError("ssl_context must be set before using adafruit_requests for https")
-    addr_info = socket_module.getaddrinfo(host, port, 0, socket_module.SOCK_STREAM)[0]
-    sock = socket_module.socket(addr_info[0], addr_info[1], addr_info[2])
-    if proto == "https:":
-        sock = ssl_context.wrap_socket(sock, server_hostname=host)
-    sock.settimeout(timeout)  # socket read timeout
+    def read(self, size=-1):
+        if size == -1:
+            return self.content
 
-    sock.connect((host, port))
-    _socket_pool[key] = sock
-    return sock
+        return self._response.socket.recv(size)
+
+    def readinto(self, buf):
+        return self._response._readinto(buf)
 
 class Response:
     """The response from a request, contains all the headers/content"""
@@ -94,6 +82,7 @@ class Response:
         self._start_index = 0
         self._buffer_sizes = [0]
         self._receive_buffers = [bytearray(32)]
+        self._content_length = None
 
         http = self._readto(b" ")
         if not http:
@@ -101,6 +90,8 @@ class Response:
         self.status_code = int(self._readto(b" "))
         self.reason = self._readto(b"\r\n")
         self._parse_headers()
+        self._raw = None
+        self._content_read = 0
 
     def __enter__(self):
         return self
@@ -198,29 +189,58 @@ class Response:
 
         return b
 
-    def close(self):
-        """Close, delete and collect the response data"""
+    def _readinto(self, buf):
+        remaining = self._content_length - self._content_read
+        nbytes = len(buf)
+        if nbytes > remaining:
+            nbytes = remaining
+
+        if self._start_index < self._buffer_sizes[0]:
+            # print("remaining", self._start_index, self._buffer_sizes[0], self._receive_buffers[0])
+            size = self._buffer_sizes[0]
+            left = size - self._start_index
+            if nbytes < left:
+                left = nbytes
+            start = self._start_index
+            end = start + left
+            if left == 1:
+                buf[0] = self._receive_buffers[0][start]
+            else:
+                buf[:] = self._receive_buffers[0][start:end]
+            read = left
+            self._start_index += left
+            if read < nbytes:
+                read += self.socket.recv_into(memoryview(buf)[left:nbytes])
+        else:
+            read = self.socket.recv_into(buf, nbytes)
+        self._content_read += read
+        return read
+
+    def _throw_away(self, nbytes):
+        buf = self._receive_buffers[0]
+        for i in range(nbytes // len(buf)):
+            self.socket.recv_into(buf)
+        remaining = nbytes % len(buf)
+        if remaining:
+            self.socket.recv_into(buf, remaining)
+
+    def _close(self):
+        """Drain the remaining ESP socket buffers. We assume we already got what we wanted."""
         if self.socket:
             # Make sure we've read all of our response.
-            content_length = None
-            if "content-length" in self.headers:
-                content_length = int(self.headers["content-length"])
-
             # print("Content length:", content_length)
             if self._cached is None:
-                if content_length:
-                    self.socket.recv(content_length)
+                if self._content_length:
+                    self._throw_away(self._content_length)
                 else:
                     while True:
                         chunk_header = self._readto(b";", b"\r\n")
                         chunk_size = int(chunk_header, 16)
                         if chunk_size == 0:
                             break
-                        self.socket.read(chunk_size + 2)
+                        self._throw_away(chunk_size + 2)
                     self._parse_headers()
                 self.socket = None
-        del self._cached
-        gc.collect()
 
     def _parse_headers(self):
         """
@@ -234,8 +254,11 @@ class Response:
 
             content = self._readto(b"\r\n")
             if title and content:
-                title = str(title.lower(), 'utf-8')
+                title = str(title, 'utf-8')
                 content = str(content, 'utf-8')
+                # Check len first so we can skip the .lower allocation most of the time.
+                if len(title) == len("content-length") and title.lower() == "content-length":
+                    self._content_length = int(content)
                 self._headers[title] = content
 
     @property
@@ -249,33 +272,24 @@ class Response:
     @property
     def content(self):
         """The HTTP content direct from the socket, as bytes"""
-        # print(self.headers)
-        content_length = None
-        if "content-length" in self.headers:
-            content_length = int(self.headers["content-length"])
+        if self._cached is not None:
+            if isinstance(self._cached, bytes):
+                return self._cached
+            raise RuntimeError("Cannot access content after getting text or json")
 
-        # print("Content length:", content_length)
-        if self._cached is None:
-            self._cached = b"".join(self.iter_content(chunk_size=32))
-
-        # print("Buffer length:", len(self._cached))
-        # print("content", self._cached)
+        self._cached = b"".join(self.iter_content(chunk_size=32))
         return self._cached
-
-    def read(self, size=-1):
-        if size == -1:
-            return self.content
-        else:
-            raise NotImplementedError()
-
-    def readinto(self, buf):
-        pass
 
     @property
     def text(self):
         """The HTTP content, encoded into a string according to the HTTP
         header encoding"""
-        return str(self.content, self.encoding)
+        if self._cached is not None:
+            if isinstance(self._cached, str):
+                return self._cached
+            raise RuntimeError("Cannot access text after getting content or json")
+        self._cached = str(self.content, self.encoding)
+        return self._cached
 
     def json(self):
         """The HTTP content, parsed into a json dictionary"""
@@ -285,7 +299,18 @@ class Response:
         except ImportError:
             import ujson as json_module
 
-        return json_module.load(self)
+        # The cached JSON will be a list or dictionary.
+        if self._cached:
+            if isinstance(self._cached, (list, dict)):
+                return self._cached
+            raise RuntimeError("Cannot access json after getting text or content")
+        if not self._raw:
+            self._raw = _RawResponse(self)
+
+        obj = json_module.load(self._raw)
+        if not self._cached:
+            self._cached = obj
+        return obj
 
     def iter_content(self, chunk_size=1, decode_unicode=False):
         """An iterator that will stream data by only reading 'chunk_size'
@@ -293,24 +318,19 @@ class Response:
         if decode_unicode:
             raise NotImplementedError("Unicode not supported")
 
-        content_length = None
-        if "content-length" in self.headers:
-            content_length = int(self.headers["content-length"])
-
         total_read = 0
-        if content_length:
-            while total_read < content_length:
-                if total_read == 0 and self._start_index < self._buffer_sizes[0]:
-                    # print("remaining", self._start_index, self._buffer_sizes[0], self._receive_buffers[0])
-                    size = self._buffer_sizes[0]
-                    left = size - self._start_index
-                    chunk = b"".join((self._receive_buffers[0][self._start_index:size],
-                                      self.socket.recv(chunk_size - left)))
-                    # print("remaining", chunk)
+        if self._content_length:
+            while self._content_read < self._content_length:
+                remaining = self._content_length - self._content_read
+                if chunk_size > remaining:
+                    chunk_size = remaining
+                b = bytearray(chunk_size)
+                size = self._readinto(b)
+                total_read += self._content_read
+                if size < chunk_size:
+                    chunk = bytes(memoryview(b)[:size])
                 else:
-                    chunk = self.socket.recv(chunk_size)
-                    # print("recv", chunk)
-                total_read += len(chunk)
+                    chunk = bytes(b)
                 yield chunk
         else:
             pending_bytes = 0
@@ -338,103 +358,131 @@ class Response:
                 yield b"".join(chunks)
         self.socket = None
 
+class Session:
+    def __init__(self, socket_pool, ssl_context=None):
+        self._socket_pool = socket_pool
+        self._ssl_context = ssl_context
+        # Hang onto open sockets so that we can reuse them.
+        self._open_sockets = {}
+        self._last_response = None
 
-# pylint: disable=too-many-branches, too-many-statements, unused-argument, too-many-arguments, too-many-locals
-def request(method, url, data=None, json=None, headers=None, stream=False, timeout=60):
-    """Perform an HTTP request to the given url which we will parse to determine
-    whether to use SSL ('https://') or not. We can also send some provided 'data'
-    or a json dictionary which we will stringify. 'headers' is optional HTTP headers
-    sent along. 'stream' will determine if we buffer everything, or whether to only
-    read only when requested
-    """
-    if not headers:
-        headers = {}
+    def _get_socket(self, host, port, proto, *, timeout=1):
+        key = (host, port, proto)
+        if key in self._open_sockets:
+            return self._open_sockets[key]
+        if proto == "https:" and not self._ssl_context:
+            raise RuntimeError("ssl_context must be set before using adafruit_requests for https")
+        addr_info = self._socket_pool.getaddrinfo(host, port, 0, self._socket_pool.SOCK_STREAM)[0]
+        sock = self._socket_pool.socket(addr_info[0], addr_info[1], addr_info[2])
+        if proto == "https:":
+            sock = self._ssl_context.wrap_socket(sock, server_hostname=host)
+        sock.settimeout(timeout)  # socket read timeout
 
-    try:
-        proto, dummy, host, path = url.split("/", 3)
-        # replace spaces in path
-        path = path.replace(" ", "%20")
-    except ValueError:
-        proto, dummy, host = url.split("/", 2)
-        path = ""
-    if proto == "http:":
-        port = 80
-    elif proto == "https:":
-        port = 443
-    else:
-        raise ValueError("Unsupported protocol: " + proto)
+        sock.connect((host, port))
+        self._open_sockets[key] = sock
+        return sock
 
-    if ":" in host:
-        host, port = host.split(":", 1)
-        port = int(port)
+    # pylint: disable=too-many-branches, too-many-statements, unused-argument, too-many-arguments, too-many-locals
+    def request(self, method, url, data=None, json=None, headers=None, stream=False, timeout=60):
+        """Perform an HTTP request to the given url which we will parse to determine
+        whether to use SSL ('https://') or not. We can also send some provided 'data'
+        or a json dictionary which we will stringify. 'headers' is optional HTTP headers
+        sent along. 'stream' will determine if we buffer everything, or whether to only
+        read only when requested
+        """
+        if not headers:
+            headers = {}
 
-    socket = _get_socket(host, port, proto, timeout=timeout)
-    socket.send(b"%s /%s HTTP/1.1\r\n" % (bytes(method, "utf-8"), bytes(path, "utf-8")))
-    if "Host" not in headers:
-        socket.send(b"Host: %s\r\n" % bytes(host, "utf-8"))
-    if "User-Agent" not in headers:
-        socket.send(b"User-Agent: Adafruit CircuitPython\r\n")
-    # Iterate over keys to avoid tuple alloc
-    for k in headers:
-        socket.send(k.encode())
-        socket.send(b": ")
-        socket.send(headers[k].encode())
-        socket.send(b"\r\n")
-    if json is not None:
-        assert data is None
-        # pylint: disable=import-outside-toplevel
         try:
-            import json as json_module
-        except ImportError:
-            import ujson as json_module
-        data = json_module.dumps(json)
-        socket.send(b"Content-Type: application/json\r\n")
-    if data:
-        if isinstance(data, dict):
-            sock.send(b"Content-Type: application/x-www-form-urlencoded\r\n")
-            _post_data = ""
-            for k in data:
-                _post_data = "{}&{}={}".format(_post_data, k, data[k])
-            data = _post_data[1:]
-        socket.send(b"Content-Length: %d\r\n" % len(data))
-    socket.send(b"\r\n")
-    if data:
-        if isinstance(data, bytearray):
-            socket.send(bytes(data))
+            proto, dummy, host, path = url.split("/", 3)
+            # replace spaces in path
+            path = path.replace(" ", "%20")
+        except ValueError:
+            proto, dummy, host = url.split("/", 2)
+            path = ""
+        if proto == "http:":
+            port = 80
+        elif proto == "https:":
+            port = 443
         else:
-            socket.send(bytes(data, "utf-8"))
+            raise ValueError("Unsupported protocol: " + proto)
 
-    resp = Response(socket)  # our response
-    if "location" in resp.headers and not 200 <= resp.status_code <= 299:
-        raise NotImplementedError("Redirects not yet supported")
+        if ":" in host:
+            host, port = host.split(":", 1)
+            port = int(port)
 
-    return resp
+        if self._last_response:
+            self._last_response._close()
+            self._last_response = None
 
-def head(url, **kw):
-    """Send HTTP HEAD request"""
-    return request("HEAD", url, **kw)
+        socket = self._get_socket(host, port, proto, timeout=timeout)
+        socket.send(b"%s /%s HTTP/1.1\r\n" % (bytes(method, "utf-8"), bytes(path, "utf-8")))
+        if "Host" not in headers:
+            socket.send(b"Host: %s\r\n" % bytes(host, "utf-8"))
+        if "User-Agent" not in headers:
+            socket.send(b"User-Agent: Adafruit CircuitPython\r\n")
+        # Iterate over keys to avoid tuple alloc
+        for k in headers:
+            socket.send(k.encode())
+            socket.send(b": ")
+            socket.send(headers[k].encode())
+            socket.send(b"\r\n")
+        if json is not None:
+            assert data is None
+            # pylint: disable=import-outside-toplevel
+            try:
+                import json as json_module
+            except ImportError:
+                import ujson as json_module
+            data = json_module.dumps(json)
+            socket.send(b"Content-Type: application/json\r\n")
+        if data:
+            if isinstance(data, dict):
+                sock.send(b"Content-Type: application/x-www-form-urlencoded\r\n")
+                _post_data = ""
+                for k in data:
+                    _post_data = "{}&{}={}".format(_post_data, k, data[k])
+                data = _post_data[1:]
+            socket.send(b"Content-Length: %d\r\n" % len(data))
+        socket.send(b"\r\n")
+        if data:
+            if isinstance(data, bytearray):
+                socket.send(bytes(data))
+            else:
+                socket.send(bytes(data, "utf-8"))
+
+        resp = Response(socket)  # our response
+        if "location" in resp.headers and not 200 <= resp.status_code <= 299:
+            raise NotImplementedError("Redirects not yet supported")
+
+        self._last_response = resp
+        return resp
+
+    def head(self, url, **kw):
+        """Send HTTP HEAD request"""
+        return self.request("HEAD", url, **kw)
 
 
-def get(url, **kw):
-    """Send HTTP GET request"""
-    return request("GET", url, **kw)
+    def get(self, url, **kw):
+        """Send HTTP GET request"""
+        return self.request("GET", url, **kw)
 
 
-def post(url, **kw):
-    """Send HTTP POST request"""
-    return request("POST", url, **kw)
+    def post(self, url, **kw):
+        """Send HTTP POST request"""
+        return self.request("POST", url, **kw)
 
 
-def put(url, **kw):
-    """Send HTTP PUT request"""
-    return request("PUT", url, **kw)
+    def put(self, url, **kw):
+        """Send HTTP PUT request"""
+        return self.request("PUT", url, **kw)
 
 
-def patch(url, **kw):
-    """Send HTTP PATCH request"""
-    return request("PATCH", url, **kw)
+    def patch(self, url, **kw):
+        """Send HTTP PATCH request"""
+        return self.request("PATCH", url, **kw)
 
 
-def delete(url, **kw):
-    """Send HTTP DELETE request"""
-    return request("DELETE", url, **kw)
+    def delete(self, url, **kw):
+        """Send HTTP DELETE request"""
+        return self.request("DELETE", url, **kw)

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -54,22 +54,40 @@ import gc
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Requests.git"
 
-_the_interface = None  # pylint: disable=invalid-name
-_the_sock = None  # pylint: disable=invalid-name
+# This module mirror CPython's socket class. It is settable because the network devices are external
+# to CircuitPython.
+_socket = None  # pylint: disable=invalid-name
 
 
-def set_socket(sock, iface=None):
-    """Helper to set the global socket and optionally set the global network interface.
-    :param sock: socket object.
-    :param iface: internet interface object
+def set_socket(socket):
+    """Helper to set the global socket.
+    :param sock: socket module
 
     """
-    global _the_sock  # pylint: disable=invalid-name, global-statement
-    _the_sock = sock
-    if iface:
-        global _the_interface  # pylint: disable=invalid-name, global-statement
-        _the_interface = iface
-        _the_sock.set_interface(iface)
+    global _socket  # pylint: disable=invalid-name, global-statement
+    _socket = socket
+
+# Hang onto open sockets so that we can reuse them.
+_socket_pool = {}
+def _get_socket(host, port, proto, *, timeout=1):
+    key = (host, port, proto)
+    if key in _socket_pool:
+        socket = _socket_pool[key]
+        if not socket.connected():
+            del _socket_pool[key]
+        else:
+            return socket
+    addr_info = _socket.getaddrinfo(host, port, 0, _socket.SOCK_STREAM)[0]
+    sock = _socket.socket(addr_info[0], addr_info[1], addr_info[2])
+    sock.settimeout(timeout)  # socket read timeout
+
+    if proto == "https:":
+        # for SSL we need to know the host name
+        sock.connect((host, port), _socket.TLS_MODE)
+    else:
+        sock.connect(addr_info[-1], _socket.TCP_MODE)
+    _socket_pool[key] = sock
+    return sock
 
 
 class Response:
@@ -81,10 +99,20 @@ class Response:
         self.socket = sock
         self.encoding = "utf-8"
         self._cached = None
-        self.status_code = None
-        self.reason = None
-        self._read_so_far = 0
-        self.headers = {}
+        self._headers = {}
+
+        if not self.socket.connected():
+            raise RuntimeError("We were too slow")
+
+        line = self.socket.readline()
+        if line is None:
+            raise RuntimeError("Unable to read HTTP response.")
+        line = line.split(b" ", 2)
+        self.status_code = int(line[1])
+        self.reason = ""
+        if len(line) > 2:
+            self.reason = line[2].rstrip()
+        self._parse_headers()
 
     def __enter__(self):
         return self
@@ -95,26 +123,83 @@ class Response:
     def close(self):
         """Close, delete and collect the response data"""
         if self.socket:
-            self.socket.close()
-            del self.socket
+            # Make sure we've read all of our response.
+            content_length = None
+            if "content-length" in self.headers:
+                content_length = int(self.headers["content-length"])
+
+            # print("Content length:", content_length)
+            if self._cached is None:
+                if content_length:
+                    self.socket.recv(content_length)
+                else:
+                    while True:
+                        chunk_header = self.socket.readline()
+                        if b";" in chunk_header:
+                            chunk_header = chunk_header.split(b";")[0]
+                        chunk_size = int(chunk_header, 16)
+                        if chunk_size == 0:
+                            break
+                        self.socket.read(chunk_size + 2)
+                    self._parse_headers()
+                self.socket = None
         del self._cached
         gc.collect()
+
+    def _parse_headers(self):
+        """
+        Parses the header portion of an HTTP request/response from the socket.
+        Expects first line of HTTP request/response to have been read already.
+        """
+        while True:
+            line = self.socket.readline()
+            if not line or line == b"\r\n":
+                break
+
+            #print("**line: ", line)
+            splits = line.split(b': ', 1)
+            title = splits[0]
+            content = ''
+            if len(splits) > 1:
+                content = splits[1]
+            if title and content:
+                title = str(title.lower(), 'utf-8')
+                content = str(content, 'utf-8')
+                self._headers[title] = content
+
+    @property
+    def headers(self):
+        return self._headers
 
     @property
     def content(self):
         """The HTTP content direct from the socket, as bytes"""
         # print(self.headers)
-        try:
+        content_length = None
+        if "content-length" in self.headers:
             content_length = int(self.headers["content-length"])
-        except KeyError:
-            content_length = 0
+
         # print("Content length:", content_length)
         if self._cached is None:
-            try:
+            if content_length:
                 self._cached = self.socket.recv(content_length)
-            finally:
-                self.socket.close()
-                self.socket = None
+            else:
+                chunks = []
+                while True:
+                    chunk_header = self.socket.readline()
+                    if chunk_header is None:
+                        raise RuntimeError("Reading content timed out.")
+                    if b";" in chunk_header:
+                        chunk_header = chunk_header.split(b";")[0]
+                    chunk_size = int(chunk_header, 16)
+                    if chunk_size == 0:
+                        break
+                    chunks.append(self.socket.read(chunk_size))
+                    self.socket.read(2) # Read the trailing CR LF
+                self._parse_headers()
+                self._cached = b"".join(chunks)
+            self.socket = None
+
         # print("Buffer length:", len(self._cached))
         return self._cached
 
@@ -131,6 +216,7 @@ class Response:
             import json as json_module
         except ImportError:
             import ujson as json_module
+
         return json_module.loads(self.content)
 
     def iter_content(self, chunk_size=1, decode_unicode=False):
@@ -139,16 +225,47 @@ class Response:
         if decode_unicode:
             raise NotImplementedError("Unicode not supported")
 
-        while True:
-            chunk = self.socket.recv(chunk_size)
-            if chunk:
+        content_length = None
+        if "content-length" in self.headers:
+            content_length = int(self.headers["content-length"])
+
+        total_read = 0
+        if content_length:
+            while total_read < content_length:
+                chunk = self.socket.recv(chunk_size)
+                total_read += chunk_size
                 yield chunk
-            else:
-                return
+        else:
+            pending_bytes = 0
+            chunks = []
+            while True:
+                chunk_header = self.socket.readline()
+                if b";" in chunk_header:
+                    chunk_header = chunk_header.split(b";")[0]
+                http_chunk_size = int(chunk_header, 16)
+                if http_chunk_size == 0:
+                    break
+                remaining_in_http_chunk = http_chunk_size
+                while remaining_in_http_chunk:
+                    read_now = chunk_size - pending_bytes
+                    if read_now > remaining_in_http_chunk:
+                        read_now = remaining_in_http_chunk
+                    chunks.append(self.socket.read(read_now))
+                    pending_bytes += read_now
+                    if pending_bytes == chunk_size:
+                        yield b"".join(chunks)
+                        pending_bytes = 0
+                        chunks = []
+
+                self.socket.read(2) # Read the trailing CR LF
+            self._parse_headers()
+            if chunks:
+                yield b"".join(chunks)
+        self.socket = None
 
 
 # pylint: disable=too-many-branches, too-many-statements, unused-argument, too-many-arguments, too-many-locals
-def request(method, url, data=None, json=None, headers=None, stream=False, timeout=1):
+def request(method, url, data=None, json=None, headers=None, stream=False, timeout=60):
     """Perform an HTTP request to the given url which we will parse to determine
     whether to use SSL ('https://') or not. We can also send some provided 'data'
     or a json dictionary which we will stringify. 'headers' is optional HTTP headers
@@ -156,7 +273,7 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
     read only when requested
     """
     global _the_interface  # pylint: disable=global-statement, invalid-name
-    global _the_sock  # pylint: disable=global-statement, invalid-name
+    global _socket  # pylint: disable=global-statement, invalid-name
 
     if not headers:
         headers = {}
@@ -179,107 +296,46 @@ def request(method, url, data=None, json=None, headers=None, stream=False, timeo
         host, port = host.split(":", 1)
         port = int(port)
 
-    addr_info = _the_sock.getaddrinfo(host, port, 0, _the_sock.SOCK_STREAM)[0]
-    sock = _the_sock.socket(addr_info[0], addr_info[1], addr_info[2])
-    resp = Response(sock)  # our response
-
-    sock.settimeout(timeout)  # socket read timeout
-
-    try:
-        if proto == "https:":
-            conntype = _the_interface.TLS_MODE
-            sock.connect(
-                (host, port), conntype
-            )  # for SSL we need to know the host name
+    socket = _get_socket(host, port, proto, timeout=timeout)
+    socket.send(b"%s /%s HTTP/1.1\r\n" % (bytes(method, "utf-8"), bytes(path, "utf-8")))
+    if "Host" not in headers:
+        socket.send(b"Host: %s\r\n" % bytes(host, "utf-8"))
+    if "User-Agent" not in headers:
+        socket.send(b"User-Agent: Adafruit CircuitPython\r\n")
+    # Iterate over keys to avoid tuple alloc
+    for k in headers:
+        socket.send(k.encode())
+        socket.send(b": ")
+        socket.send(headers[k].encode())
+        socket.send(b"\r\n")
+    if json is not None:
+        assert data is None
+        try:
+            import json as json_module
+        except ImportError:
+            import ujson as json_module
+        data = json_module.dumps(json)
+        socket.send(b"Content-Type: application/json\r\n")
+    if data:
+        if isinstance(data, dict):
+            sock.send(b"Content-Type: application/x-www-form-urlencoded\r\n")
+            _post_data = ""
+            for k in data:
+                _post_data = "{}&{}={}".format(_post_data, k, data[k])
+            data = _post_data[1:]
+        socket.send(b"Content-Length: %d\r\n" % len(data))
+    socket.send(b"\r\n")
+    if data:
+        if isinstance(data, bytearray):
+            socket.send(bytes(data))
         else:
-            conntype = _the_interface.TCP_MODE
-            sock.connect(addr_info[-1], conntype)
-        sock.send(
-            b"%s /%s HTTP/1.0\r\n" % (bytes(method, "utf-8"), bytes(path, "utf-8"))
-        )
-        if "Host" not in headers:
-            sock.send(b"Host: %s\r\n" % bytes(host, "utf-8"))
-        if "User-Agent" not in headers:
-            sock.send(b"User-Agent: Adafruit CircuitPython\r\n")
-        # Iterate over keys to avoid tuple alloc
-        for k in headers:
-            sock.send(k.encode())
-            sock.send(b": ")
-            sock.send(headers[k].encode())
-            sock.send(b"\r\n")
-        if json is not None:
-            assert data is None
-            # pylint: disable=import-outside-toplevel
-            try:
-                import json as json_module
-            except ImportError:
-                import ujson as json_module
-            # pylint: enable=import-outside-toplevel
-            data = json_module.dumps(json)
-            sock.send(b"Content-Type: application/json\r\n")
-        if data:
-            if isinstance(data, dict):
-                sock.send(b"Content-Type: application/x-www-form-urlencoded\r\n")
-                _post_data = ""
-                for k in data:
-                    _post_data = "{}&{}={}".format(_post_data, k, data[k])
-                data = _post_data[1:]
-            sock.send(b"Content-Length: %d\r\n" % len(data))
-        sock.send(b"\r\n")
-        if data:
-            if isinstance(data, bytearray):
-                sock.send(bytes(data))
-            else:
-                sock.send(bytes(data, "utf-8"))
+            socket.send(bytes(data, "utf-8"))
 
-        line = sock.readline()
-        # print(line)
-        line = line.split(None, 2)
-        status = int(line[1])
-        reason = ""
-        if len(line) > 2:
-            reason = line[2].rstrip()
-        resp.headers = parse_headers(sock)
-        if resp.headers.get("transfer-encoding"):
-            if "chunked" in resp.headers.get("transfer-encoding"):
-                raise ValueError("Unsupported " + resp.headers.get("transfer-encoding"))
-        elif resp.headers.get("location") and not 200 <= status <= 299:
-            raise NotImplementedError("Redirects not yet supported")
+    resp = Response(socket)  # our response
+    if "location" in resp.headers and not 200 <= resp.status_code <= 299:
+        raise NotImplementedError("Redirects not yet supported")
 
-    except:
-        sock.close()
-        raise
-
-    resp.status_code = status
-    resp.reason = reason
     return resp
-
-
-def parse_headers(sock):
-    """
-    Parses the header portion of an HTTP request/response from the socket.
-    Expects first line of HTTP request/response to have been read already
-    return: header dictionary
-    rtype: Dict
-    """
-    headers = {}
-    while True:
-        line = sock.readline()
-        if not line or line == b"\r\n":
-            break
-
-        # print("**line: ", line)
-        splits = line.split(b": ", 1)
-        title = splits[0]
-        content = ""
-        if len(splits) > 1:
-            content = splits[1]
-        if title and content:
-            title = str(title.lower(), "utf-8")
-            content = str(content, "utf-8")
-            headers[title] = content
-    return headers
-
 
 def head(url, **kw):
     """Send HTTP HEAD request"""

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -527,6 +527,7 @@ class Session:
 
 _default_session = None  # pylint: disable=invalid-name
 
+
 class _FakeSSLSocket:
     def __init__(self, socket, tls_mode):
         self._socket = socket
@@ -537,6 +538,7 @@ class _FakeSSLSocket:
 
     def connect(self, address):
         return self._socket.connect(address, self._mode)
+
 
 class _FakeSSLContext:
     def __init__(self, iface):

--- a/examples/requests_advanced.py
+++ b/examples/requests_advanced.py
@@ -9,7 +9,11 @@ import adafruit_requests as requests
 # "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
 # source control.
 # pylint: disable=no-name-in-module,wrong-import-order
-from secrets import secrets
+try:
+    from secrets import secrets
+except ImportError:
+    print("WiFi secrets are kept in secrets.py, please add them there!")
+    raise
 
 # If you are using a board with pre-defined ESP32 Pins:
 esp32_cs = DigitalInOut(board.ESP_CS)

--- a/examples/requests_advanced.py
+++ b/examples/requests_advanced.py
@@ -8,6 +8,7 @@ import adafruit_requests as requests
 # Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
 # "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
 # source control.
+# pylint: disable=no-name-in-module,wrong-import-order
 from secrets import secrets
 
 # If you are using a board with pre-defined ESP32 Pins:

--- a/examples/requests_advanced.py
+++ b/examples/requests_advanced.py
@@ -5,6 +5,11 @@ import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 from adafruit_esp32spi import adafruit_esp32spi
 import adafruit_requests as requests
 
+# Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
+# "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
+# source control.
+from secrets import secrets
+
 # If you are using a board with pre-defined ESP32 Pins:
 esp32_cs = DigitalInOut(board.ESP_CS)
 esp32_ready = DigitalInOut(board.ESP_BUSY)
@@ -21,14 +26,15 @@ esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 print("Connecting to AP...")
 while not esp.is_connected:
     try:
-        esp.connect_AP(b"MY_SSID_NAME", b"MY_SSID_PASSWORD")
+        esp.connect_AP(secrets["ssid"], secrets["password"])
     except RuntimeError as e:
         print("could not connect to AP, retrying: ", e)
         continue
 print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
 
 # Initialize a requests object with a socket and esp32spi interface
-requests.set_socket(socket, esp)
+socket.set_interface(esp)
+requests.set_socket(socket)
 
 JSON_GET_URL = "http://httpbin.org/get"
 

--- a/examples/requests_advanced_cpython.py
+++ b/examples/requests_advanced_cpython.py
@@ -1,6 +1,7 @@
 import socket
-import adafruit_requests as requests
-requests.socket_module = socket
+import adafruit_requests
+
+http = adafruit_requests.Session(socket)
 
 JSON_GET_URL = "http://httpbin.org/get"
 
@@ -8,7 +9,7 @@ JSON_GET_URL = "http://httpbin.org/get"
 headers = {"user-agent": "blinka/1.0.0"}
 
 print("Fetching JSON data from %s..." % JSON_GET_URL)
-response = requests.get(JSON_GET_URL, headers=headers)
+response = http.get(JSON_GET_URL, headers=headers)
 print("-" * 60)
 
 json_data = response.json()

--- a/examples/requests_advanced_cpython.py
+++ b/examples/requests_advanced_cpython.py
@@ -1,0 +1,27 @@
+import socket
+import adafruit_requests as requests
+requests.socket_module = socket
+
+JSON_GET_URL = "http://httpbin.org/get"
+
+# Define a custom header as a dict.
+headers = {"user-agent": "blinka/1.0.0"}
+
+print("Fetching JSON data from %s..." % JSON_GET_URL)
+response = requests.get(JSON_GET_URL, headers=headers)
+print("-" * 60)
+
+json_data = response.json()
+headers = json_data["headers"]
+print("Response's Custom User-Agent Header: {0}".format(headers["User-Agent"]))
+print("-" * 60)
+
+# Read Response's HTTP status code
+print("Response HTTP Status Code: ", response.status_code)
+print("-" * 60)
+
+# Read Response, as raw bytes instead of pretty text
+print("Raw Response: ", response.content)
+
+# Close, delete and collect the response data
+response.close()

--- a/examples/requests_github_cpython.py
+++ b/examples/requests_github_cpython.py
@@ -7,7 +7,7 @@ http = adafruit_requests.Session(socket, ssl.create_default_context())
 
 print("Getting CircuitPython star count")
 headers = {"Transfer-Encoding": "chunked"}
-response = http.get("https://api.github.com/repos/adafruit/circuitpython", headers=headers)
-print(response.headers)
+response = http.get(
+    "https://api.github.com/repos/adafruit/circuitpython", headers=headers
+)
 print("circuitpython stars", response.json()["stargazers_count"])
-

--- a/examples/requests_github_cpython.py
+++ b/examples/requests_github_cpython.py
@@ -1,0 +1,13 @@
+# adafruit_requests usage with a CPython socket
+import socket
+import ssl
+import adafruit_requests
+
+http = adafruit_requests.Session(socket, ssl.create_default_context())
+
+print("Getting CircuitPython star count")
+headers = {"Transfer-Encoding": "chunked"}
+response = http.get("https://api.github.com/repos/adafruit/circuitpython", headers=headers)
+print(response.headers)
+print("circuitpython stars", response.json()["stargazers_count"])
+

--- a/examples/requests_https_cpython.py
+++ b/examples/requests_https_cpython.py
@@ -2,8 +2,8 @@
 import socket
 import ssl
 import adafruit_requests as requests
-requests.socket_module = socket
-requests.ssl_context = ssl.create_default_context()
+
+http = requests.Session(socket, ssl.create_default_context())
 
 TEXT_URL = "https://wifitest.adafruit.com/testwifi/index.html"
 JSON_GET_URL = "https://httpbin.org/get"
@@ -18,31 +18,28 @@ JSON_POST_URL = "https://httpbin.org/post"
 # response.close()
 
 print("Fetching JSON data from %s" % JSON_GET_URL)
-response = requests.get(JSON_GET_URL)
+response = http.get(JSON_GET_URL)
 print("-" * 40)
 
 print("JSON Response: ", response.json())
 print("-" * 40)
-response.close()
 
 data = "31F"
 print("POSTing data to {0}: {1}".format(JSON_POST_URL, data))
-response = requests.post(JSON_POST_URL, data=data)
+response = http.post(JSON_POST_URL, data=data)
 print("-" * 40)
 
 json_resp = response.json()
 # Parse out the 'data' key from json_resp dict.
 print("Data received from server:", json_resp["data"])
 print("-" * 40)
-response.close()
 
 json_data = {"Date": "July 25, 2019"}
 print("POSTing data to {0}: {1}".format(JSON_POST_URL, json_data))
-response = requests.post(JSON_POST_URL, json=json_data)
+response = http.post(JSON_POST_URL, json=json_data)
 print("-" * 40)
 
 json_resp = response.json()
 # Parse out the 'json' key from json_resp dict.
 print("JSON Data received from server:", json_resp["json"])
 print("-" * 40)
-response.close()

--- a/examples/requests_https_cpython.py
+++ b/examples/requests_https_cpython.py
@@ -3,7 +3,7 @@ import socket
 import ssl
 import adafruit_requests as requests
 
-http = requests.Session(socket, ssl.create_default_context())
+https = requests.Session(socket, ssl.create_default_context())
 
 TEXT_URL = "https://wifitest.adafruit.com/testwifi/index.html"
 JSON_GET_URL = "https://httpbin.org/get"
@@ -18,7 +18,7 @@ JSON_POST_URL = "https://httpbin.org/post"
 # response.close()
 
 print("Fetching JSON data from %s" % JSON_GET_URL)
-response = http.get(JSON_GET_URL)
+response = https.get(JSON_GET_URL)
 print("-" * 40)
 
 print("JSON Response: ", response.json())
@@ -26,7 +26,7 @@ print("-" * 40)
 
 data = "31F"
 print("POSTing data to {0}: {1}".format(JSON_POST_URL, data))
-response = http.post(JSON_POST_URL, data=data)
+response = https.post(JSON_POST_URL, data=data)
 print("-" * 40)
 
 json_resp = response.json()
@@ -36,7 +36,7 @@ print("-" * 40)
 
 json_data = {"Date": "July 25, 2019"}
 print("POSTing data to {0}: {1}".format(JSON_POST_URL, json_data))
-response = http.post(JSON_POST_URL, json=json_data)
+response = https.post(JSON_POST_URL, json=json_data)
 print("-" * 40)
 
 json_resp = response.json()

--- a/examples/requests_https_cpython.py
+++ b/examples/requests_https_cpython.py
@@ -1,0 +1,48 @@
+# adafruit_requests usage with a CPython socket
+import socket
+import ssl
+import adafruit_requests as requests
+requests.socket_module = socket
+requests.ssl_context = ssl.create_default_context()
+
+TEXT_URL = "https://wifitest.adafruit.com/testwifi/index.html"
+JSON_GET_URL = "https://httpbin.org/get"
+JSON_POST_URL = "https://httpbin.org/post"
+
+# print("Fetching text from %s" % TEXT_URL)
+# response = requests.get(TEXT_URL)
+# print("-" * 40)
+
+# print("Text Response: ", response.text)
+# print("-" * 40)
+# response.close()
+
+print("Fetching JSON data from %s" % JSON_GET_URL)
+response = requests.get(JSON_GET_URL)
+print("-" * 40)
+
+print("JSON Response: ", response.json())
+print("-" * 40)
+response.close()
+
+data = "31F"
+print("POSTing data to {0}: {1}".format(JSON_POST_URL, data))
+response = requests.post(JSON_POST_URL, data=data)
+print("-" * 40)
+
+json_resp = response.json()
+# Parse out the 'data' key from json_resp dict.
+print("Data received from server:", json_resp["data"])
+print("-" * 40)
+response.close()
+
+json_data = {"Date": "July 25, 2019"}
+print("POSTing data to {0}: {1}".format(JSON_POST_URL, json_data))
+response = requests.post(JSON_POST_URL, json=json_data)
+print("-" * 40)
+
+json_resp = response.json()
+# Parse out the 'json' key from json_resp dict.
+print("JSON Data received from server:", json_resp["json"])
+print("-" * 40)
+response.close()

--- a/examples/requests_simpletest.py
+++ b/examples/requests_simpletest.py
@@ -6,6 +6,11 @@ import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 from adafruit_esp32spi import adafruit_esp32spi
 import adafruit_requests as requests
 
+# Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
+# "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
+# source control.
+from secrets import secrets
+
 # If you are using a board with pre-defined ESP32 Pins:
 esp32_cs = DigitalInOut(board.ESP_CS)
 esp32_ready = DigitalInOut(board.ESP_BUSY)
@@ -22,14 +27,15 @@ esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 print("Connecting to AP...")
 while not esp.is_connected:
     try:
-        esp.connect_AP(b"MY_SSID_NAME", b"MY_SSID_PASSWORD")
+        esp.connect_AP(secrets["ssid"], secrets["password"])
     except RuntimeError as e:
         print("could not connect to AP, retrying: ", e)
         continue
 print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
 
 # Initialize a requests object with a socket and esp32spi interface
-requests.set_socket(socket, esp)
+socket.set_interface(esp)
+requests.set_socket(socket)
 
 TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
 JSON_GET_URL = "http://httpbin.org/get"

--- a/examples/requests_simpletest.py
+++ b/examples/requests_simpletest.py
@@ -10,7 +10,11 @@ import adafruit_requests as requests
 # "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
 # source control.
 # pylint: disable=no-name-in-module,wrong-import-order
-from secrets import secrets
+try:
+    from secrets import secrets
+except ImportError:
+    print("WiFi secrets are kept in secrets.py, please add them there!")
+    raise
 
 # If you are using a board with pre-defined ESP32 Pins:
 esp32_cs = DigitalInOut(board.ESP_CS)

--- a/examples/requests_simpletest.py
+++ b/examples/requests_simpletest.py
@@ -9,6 +9,7 @@ import adafruit_requests as requests
 # Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
 # "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
 # source control.
+# pylint: disable=no-name-in-module,wrong-import-order
 from secrets import secrets
 
 # If you are using a board with pre-defined ESP32 Pins:

--- a/examples/requests_simpletest_cpython.py
+++ b/examples/requests_simpletest_cpython.py
@@ -1,22 +1,22 @@
 # adafruit_requests usage with a CPython socket
 import socket
-import adafruit_requests as requests
-requests.socket_module = socket
+import adafruit_requests
+
+http = adafruit_requests.Session(socket)
 
 TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
 JSON_GET_URL = "http://httpbin.org/get"
 JSON_POST_URL = "http://httpbin.org/post"
 
 print("Fetching text from %s" % TEXT_URL)
-response = requests.get(TEXT_URL)
+response = http.get(TEXT_URL)
 print("-" * 40)
 
 print("Text Response: ", response.text)
 print("-" * 40)
-response.close()
 
 print("Fetching JSON data from %s" % JSON_GET_URL)
-response = requests.get(JSON_GET_URL)
+response = http.get(JSON_GET_URL)
 print("-" * 40)
 
 print("JSON Response: ", response.json())
@@ -25,22 +25,20 @@ response.close()
 
 data = "31F"
 print("POSTing data to {0}: {1}".format(JSON_POST_URL, data))
-response = requests.post(JSON_POST_URL, data=data)
+response = http.post(JSON_POST_URL, data=data)
 print("-" * 40)
 
 json_resp = response.json()
 # Parse out the 'data' key from json_resp dict.
 print("Data received from server:", json_resp["data"])
 print("-" * 40)
-response.close()
 
 json_data = {"Date": "July 25, 2019"}
 print("POSTing data to {0}: {1}".format(JSON_POST_URL, json_data))
-response = requests.post(JSON_POST_URL, json=json_data)
+response = http.post(JSON_POST_URL, json=json_data)
 print("-" * 40)
 
 json_resp = response.json()
 # Parse out the 'json' key from json_resp dict.
 print("JSON Data received from server:", json_resp["json"])
 print("-" * 40)
-response.close()

--- a/examples/requests_simpletest_cpython.py
+++ b/examples/requests_simpletest_cpython.py
@@ -1,0 +1,46 @@
+# adafruit_requests usage with a CPython socket
+import socket
+import adafruit_requests as requests
+requests.socket_module = socket
+
+TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
+JSON_GET_URL = "http://httpbin.org/get"
+JSON_POST_URL = "http://httpbin.org/post"
+
+print("Fetching text from %s" % TEXT_URL)
+response = requests.get(TEXT_URL)
+print("-" * 40)
+
+print("Text Response: ", response.text)
+print("-" * 40)
+response.close()
+
+print("Fetching JSON data from %s" % JSON_GET_URL)
+response = requests.get(JSON_GET_URL)
+print("-" * 40)
+
+print("JSON Response: ", response.json())
+print("-" * 40)
+response.close()
+
+data = "31F"
+print("POSTing data to {0}: {1}".format(JSON_POST_URL, data))
+response = requests.post(JSON_POST_URL, data=data)
+print("-" * 40)
+
+json_resp = response.json()
+# Parse out the 'data' key from json_resp dict.
+print("Data received from server:", json_resp["data"])
+print("-" * 40)
+response.close()
+
+json_data = {"Date": "July 25, 2019"}
+print("POSTing data to {0}: {1}".format(JSON_POST_URL, json_data))
+response = requests.post(JSON_POST_URL, json=json_data)
+print("-" * 40)
+
+json_resp = response.json()
+# Parse out the 'json' key from json_resp dict.
+print("JSON Data received from server:", json_resp["json"])
+print("-" * 40)
+response.close()

--- a/tests/chunk_test.py
+++ b/tests/chunk_test.py
@@ -8,6 +8,7 @@ path = "/testwifi/index.html"
 text = b"This is a test of Adafruit WiFi!\r\nIf you can read this, its working :)"
 headers = b"HTTP/1.0 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
 
+
 def _chunk(response, split):
     i = 0
     chunked = b""
@@ -17,11 +18,14 @@ def _chunk(response, split):
         if remaining < chunk_size:
             chunk_size = remaining
         new_i = i + chunk_size
-        chunked += hex(chunk_size)[2:].encode("ascii") + b"\r\n" + response[i:new_i] + b"\r\n"
+        chunked += (
+            hex(chunk_size)[2:].encode("ascii") + b"\r\n" + response[i:new_i] + b"\r\n"
+        )
         i = new_i
     # The final chunk is zero length.
     chunked += b"0\r\n\r\n"
     return chunked
+
 
 def test_get_text():
     pool = mocket.MocketPool()
@@ -42,4 +46,3 @@ def test_get_text():
         ]
     )
     assert r.text == str(text, "utf-8")
-

--- a/tests/chunk_test.py
+++ b/tests/chunk_test.py
@@ -1,0 +1,45 @@
+from unittest import mock
+import mocket
+import adafruit_requests
+
+ip = "1.2.3.4"
+host = "wifitest.adafruit.com"
+path = "/testwifi/index.html"
+text = b"This is a test of Adafruit WiFi!\r\nIf you can read this, its working :)"
+headers = b"HTTP/1.0 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+
+def _chunk(response, split):
+    i = 0
+    chunked = b""
+    while i < len(response):
+        remaining = len(response) - i
+        chunk_size = split
+        if remaining < chunk_size:
+            chunk_size = remaining
+        new_i = i + chunk_size
+        chunked += hex(chunk_size)[2:].encode("ascii") + b"\r\n" + response[i:new_i] + b"\r\n"
+        i = new_i
+    # The final chunk is zero length.
+    chunked += b"0\r\n\r\n"
+    return chunked
+
+def test_get_text():
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
+    c = _chunk(text, 33)
+    print(c)
+    sock = mocket.Mocket(headers + c)
+    pool.socket.return_value = sock
+
+    s = adafruit_requests.Session(pool)
+    r = s.get("http://" + host + path)
+
+    sock.connect.assert_called_once_with((host, 80))
+    sock.send.assert_has_calls(
+        [
+            mock.call(b"GET /testwifi/index.html HTTP/1.1\r\n"),
+            mock.call(b"Host: wifitest.adafruit.com\r\n"),
+        ]
+    )
+    assert r.text == str(text, "utf-8")
+

--- a/tests/chunk_test.py
+++ b/tests/chunk_test.py
@@ -38,7 +38,7 @@ def test_get_text():
     s = adafruit_requests.Session(pool)
     r = s.get("http://" + host + path)
 
-    sock.connect.assert_called_once_with((host, 80))
+    sock.connect.assert_called_once_with((ip, 80))
     sock.send.assert_has_calls(
         [
             mock.call(b"GET /testwifi/index.html HTTP/1.1\r\n"),

--- a/tests/header_test.py
+++ b/tests/header_test.py
@@ -9,15 +9,16 @@ response_headers = b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n"
 
 
 def test_json():
-    mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
     sock = mocket.Mocket(response_headers)
-    mocket.socket.return_value = sock
+    pool.socket.return_value = sock
     sent = []
     sock.send.side_effect = sent.append
 
-    adafruit_requests.set_socket(mocket, mocket.interface)
+    s = adafruit_requests.Session(pool)
     headers = {"user-agent": "blinka/1.0.0"}
-    r = adafruit_requests.get("http://" + host + "/get", headers=headers)
+    r = s.get("http://" + host + "/get", headers=headers)
 
     sock.connect.assert_called_once_with((host, 80))
     sent = b"".join(sent).lower()

--- a/tests/header_test.py
+++ b/tests/header_test.py
@@ -20,7 +20,7 @@ def test_json():
     headers = {"user-agent": "blinka/1.0.0"}
     r = s.get("http://" + host + "/get", headers=headers)
 
-    sock.connect.assert_called_once_with((host, 80))
+    sock.connect.assert_called_once_with((ip, 80))
     sent = b"".join(sent).lower()
     assert b"user-agent: blinka/1.0.0\r\n" in sent
     # The current implementation sends two user agents. Fix it, and uncomment below.

--- a/tests/header_test.py
+++ b/tests/header_test.py
@@ -19,7 +19,7 @@ def test_json():
     headers = {"user-agent": "blinka/1.0.0"}
     r = adafruit_requests.get("http://" + host + "/get", headers=headers)
 
-    sock.connect.assert_called_once_with((ip, 80), mocket.interface.TCP_MODE)
+    sock.connect.assert_called_once_with((host, 80))
     sent = b"".join(sent).lower()
     assert b"user-agent: blinka/1.0.0\r\n" in sent
     # The current implementation sends two user agents. Fix it, and uncomment below.

--- a/tests/legacy_mocket.py
+++ b/tests/legacy_mocket.py
@@ -1,0 +1,32 @@
+from unittest import mock
+
+SOCK_STREAM = 0
+
+set_interface = mock.Mock()
+interface = mock.MagicMock()
+getaddrinfo = mock.Mock()
+socket = mock.Mock()
+
+
+class Mocket:
+    def __init__(self, response):
+        self.settimeout = mock.Mock()
+        self.close = mock.Mock()
+        self.connect = mock.Mock()
+        self.send = mock.Mock()
+        self.readline = mock.Mock(side_effect=self._readline)
+        self.recv = mock.Mock(side_effect=self._recv)
+        self._response = response
+        self._position = 0
+
+    def _readline(self):
+        i = self._response.find(b"\r\n", self._position)
+        r = self._response[self._position : i + 2]
+        self._position = i + 2
+        return r
+
+    def _recv(self, count):
+        end = self._position + count
+        r = self._response[self._position : end]
+        self._position = end
+        return r

--- a/tests/legacy_test.py
+++ b/tests/legacy_test.py
@@ -5,29 +5,27 @@ import adafruit_requests
 
 ip = "1.2.3.4"
 host = "httpbin.org"
-response = {}
+response = {"Date": "July 25, 2019"}
 encoded = json.dumps(response).encode("utf-8")
 headers = "HTTP/1.0 200 OK\r\nContent-Length: {}\r\n\r\n".format(len(encoded)).encode(
     "utf-8"
 )
 
-
-def test_method():
+def test_get_json():
     mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
     sock = mocket.Mocket(headers + encoded)
+    del sock.recv_into
     mocket.socket.return_value = sock
 
     adafruit_requests.set_socket(mocket, mocket.interface)
-    r = adafruit_requests.post("http://" + host + "/post")
+    r = adafruit_requests.get("http://" + host + "/get")
     sock.connect.assert_called_once_with((host, 80))
-    sock.send.assert_has_calls(
-        [mock.call(b"POST /post HTTP/1.1\r\n"), mock.call(b"Host: httpbin.org\r\n")]
-    )
+    assert r.json() == response
 
-
-def test_string():
+def test_post_string():
     mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
     sock = mocket.Mocket(headers + encoded)
+    del sock.recv_into
     mocket.socket.return_value = sock
 
     adafruit_requests.set_socket(mocket, mocket.interface)
@@ -35,15 +33,3 @@ def test_string():
     r = adafruit_requests.post("http://" + host + "/post", data=data)
     sock.connect.assert_called_once_with((host, 80))
     sock.send.assert_called_with(b"31F")
-
-
-def test_json():
-    mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
-    sock = mocket.Mocket(headers + encoded)
-    mocket.socket.return_value = sock
-
-    adafruit_requests.set_socket(mocket, mocket.interface)
-    json_data = {"Date": "July 25, 2019"}
-    r = adafruit_requests.post("http://" + host + "/post", json=json_data)
-    sock.connect.assert_called_once_with((host, 80))
-    sock.send.assert_called_with(b'{"Date": "July 25, 2019"}')

--- a/tests/legacy_test.py
+++ b/tests/legacy_test.py
@@ -20,10 +20,21 @@ def test_get_json():
     adafruit_requests.set_socket(mocket, mocket.interface)
     r = adafruit_requests.get("http://" + host + "/get")
 
-    sock.connect.assert_called_once_with((host, 80))
+    sock.connect.assert_called_once_with((ip, 80))
     assert r.json() == response
     r.close()
 
+def test_tls_mode():
+    mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
+    sock = mocket.Mocket(headers + encoded)
+    mocket.socket.return_value = sock
+
+    adafruit_requests.set_socket(mocket, mocket.interface)
+    r = adafruit_requests.get("https://" + host + "/get")
+
+    sock.connect.assert_called_once_with((host, 443), mocket.interface.TLS_MODE)
+    assert r.json() == response
+    r.close()
 
 def test_post_string():
     mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
@@ -33,6 +44,6 @@ def test_post_string():
     adafruit_requests.set_socket(mocket, mocket.interface)
     data = "31F"
     r = adafruit_requests.post("http://" + host + "/post", data=data)
-    sock.connect.assert_called_once_with((host, 80))
+    sock.connect.assert_called_once_with((ip, 80))
     sock.send.assert_called_with(b"31F")
     r.close()

--- a/tests/legacy_test.py
+++ b/tests/legacy_test.py
@@ -1,5 +1,5 @@
 from unittest import mock
-import mocket
+import legacy_mocket as mocket
 import json
 import adafruit_requests
 
@@ -11,21 +11,23 @@ headers = "HTTP/1.0 200 OK\r\nContent-Length: {}\r\n\r\n".format(len(encoded)).e
     "utf-8"
 )
 
+
 def test_get_json():
     mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
     sock = mocket.Mocket(headers + encoded)
-    del sock.recv_into
     mocket.socket.return_value = sock
 
     adafruit_requests.set_socket(mocket, mocket.interface)
     r = adafruit_requests.get("http://" + host + "/get")
+
     sock.connect.assert_called_once_with((host, 80))
     assert r.json() == response
+    r.close()
+
 
 def test_post_string():
     mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
     sock = mocket.Mocket(headers + encoded)
-    del sock.recv_into
     mocket.socket.return_value = sock
 
     adafruit_requests.set_socket(mocket, mocket.interface)
@@ -33,3 +35,4 @@ def test_post_string():
     r = adafruit_requests.post("http://" + host + "/post", data=data)
     sock.connect.assert_called_once_with((host, 80))
     sock.send.assert_called_with(b"31F")
+    r.close()

--- a/tests/legacy_test.py
+++ b/tests/legacy_test.py
@@ -24,6 +24,7 @@ def test_get_json():
     assert r.json() == response
     r.close()
 
+
 def test_tls_mode():
     mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
     sock = mocket.Mocket(headers + encoded)
@@ -35,6 +36,7 @@ def test_tls_mode():
     sock.connect.assert_called_once_with((host, 443), mocket.interface.TLS_MODE)
     assert r.json() == response
     r.close()
+
 
 def test_post_string():
     mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)

--- a/tests/mocket.py
+++ b/tests/mocket.py
@@ -1,8 +1,5 @@
 from unittest import mock
 
-set_interface = mock.Mock()
-
-interface = mock.MagicMock()
 
 class MocketPool:
     SOCK_STREAM = 0
@@ -10,6 +7,7 @@ class MocketPool:
     def __init__(self):
         self.getaddrinfo = mock.Mock()
         self.socket = mock.Mock()
+
 
 class Mocket:
     def __init__(self, response):
@@ -35,9 +33,9 @@ class Mocket:
         self._position = end
         return r
 
-    def _recv_into(self, buf, nbytes=None):
-        assert nbytes is None or nbytes > 0
-        read = nbytes if nbytes else len(buf)
+    def _recv_into(self, buf, nbytes=0):
+        assert isinstance(nbytes, int) and nbytes >= 0
+        read = nbytes if nbytes > 0 else len(buf)
         remaining = len(self._response) - self._position
         if read > remaining:
             read = remaining
@@ -45,3 +43,11 @@ class Mocket:
         buf[:read] = self._response[self._position : end]
         self._position = end
         return read
+
+
+class SSLContext:
+    def __init__(self):
+        self.wrap_socket = mock.Mock(side_effect=self._wrap_socket)
+
+    def _wrap_socket(self, sock, server_hostname=None):
+        return sock

--- a/tests/mocket.py
+++ b/tests/mocket.py
@@ -1,13 +1,15 @@
 from unittest import mock
 
-SOCK_STREAM = 0
-
-getaddrinfo = mock.Mock()
-socket = mock.Mock()
 set_interface = mock.Mock()
 
 interface = mock.MagicMock()
 
+class MocketPool:
+    SOCK_STREAM = 0
+
+    def __init__(self):
+        self.getaddrinfo = mock.Mock()
+        self.socket = mock.Mock()
 
 class Mocket:
     def __init__(self, response):
@@ -17,6 +19,7 @@ class Mocket:
         self.send = mock.Mock()
         self.readline = mock.Mock(side_effect=self._readline)
         self.recv = mock.Mock(side_effect=self._recv)
+        self.recv_into = mock.Mock(side_effect=self._recv_into)
         self._response = response
         self._position = 0
 
@@ -31,3 +34,14 @@ class Mocket:
         r = self._response[self._position : end]
         self._position = end
         return r
+
+    def _recv_into(self, buf, nbytes=None):
+        assert nbytes is None or nbytes > 0
+        read = nbytes if nbytes else len(buf)
+        remaining = len(self._response) - self._position
+        if read > remaining:
+            read = remaining
+        end = self._position + read
+        buf[:read] = self._response[self._position : end]
+        self._position = end
+        return read

--- a/tests/parse_test.py
+++ b/tests/parse_test.py
@@ -24,5 +24,5 @@ def test_json():
 
     s = adafruit_requests.Session(pool)
     r = s.get("http://" + host + "/get")
-    sock.connect.assert_called_once_with((host, 80))
+    sock.connect.assert_called_once_with((ip, 80))
     assert r.json() == response

--- a/tests/parse_test.py
+++ b/tests/parse_test.py
@@ -9,7 +9,9 @@ response = {"Date": "July 25, 2019"}
 encoded = json.dumps(response).encode("utf-8")
 # Padding here tests the case where a header line is exactly 32 bytes buffered by
 # aligning the Content-Type header after it.
-headers = "HTTP/1.0 200 OK\r\npadding: 000\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n".format(len(encoded)).encode(
+headers = "HTTP/1.0 200 OK\r\npadding: 000\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n".format(
+    len(encoded)
+).encode(
     "utf-8"
 )
 

--- a/tests/parse_test.py
+++ b/tests/parse_test.py
@@ -7,17 +7,20 @@ ip = "1.2.3.4"
 host = "httpbin.org"
 response = {"Date": "July 25, 2019"}
 encoded = json.dumps(response).encode("utf-8")
-headers = "HTTP/1.0 200 OK\r\nContent-Length: {}\r\n\r\n".format(len(encoded)).encode(
+# Padding here tests the case where a header line is exactly 32 bytes buffered by
+# aligning the Content-Type header after it.
+headers = "HTTP/1.0 200 OK\r\npadding: 000\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n".format(len(encoded)).encode(
     "utf-8"
 )
 
 
 def test_json():
-    mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
     sock = mocket.Mocket(headers + encoded)
-    mocket.socket.return_value = sock
+    pool.socket.return_value = sock
 
-    adafruit_requests.set_socket(mocket, mocket.interface)
-    r = adafruit_requests.get("http://" + host + "/get")
-    sock.connect.assert_called_once_with((ip, 80), mocket.interface.TCP_MODE)
+    s = adafruit_requests.Session(pool)
+    r = s.get("http://" + host + "/get")
+    sock.connect.assert_called_once_with((host, 80))
     assert r.json() == response

--- a/tests/post_test.py
+++ b/tests/post_test.py
@@ -39,6 +39,19 @@ def test_string():
     sock.send.assert_called_with(b"31F")
 
 
+def test_form():
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
+    sock = mocket.Mocket(headers + encoded)
+    pool.socket.return_value = sock
+
+    s = adafruit_requests.Session(pool)
+    data = {"Date": "July 25, 2019"}
+    r = s.post("http://" + host + "/post", data=data)
+    sock.connect.assert_called_once_with((host, 80))
+    sock.send.assert_called_with(b"Date=July 25, 2019")
+
+
 def test_json():
     pool = mocket.MocketPool()
     pool.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)

--- a/tests/post_test.py
+++ b/tests/post_test.py
@@ -20,7 +20,7 @@ def test_method():
 
     s = adafruit_requests.Session(pool)
     r = s.post("http://" + host + "/post")
-    sock.connect.assert_called_once_with((host, 80))
+    sock.connect.assert_called_once_with((ip, 80))
     sock.send.assert_has_calls(
         [mock.call(b"POST /post HTTP/1.1\r\n"), mock.call(b"Host: httpbin.org\r\n")]
     )
@@ -35,7 +35,7 @@ def test_string():
     s = adafruit_requests.Session(pool)
     data = "31F"
     r = s.post("http://" + host + "/post", data=data)
-    sock.connect.assert_called_once_with((host, 80))
+    sock.connect.assert_called_once_with((ip, 80))
     sock.send.assert_called_with(b"31F")
 
 
@@ -48,7 +48,7 @@ def test_form():
     s = adafruit_requests.Session(pool)
     data = {"Date": "July 25, 2019"}
     r = s.post("http://" + host + "/post", data=data)
-    sock.connect.assert_called_once_with((host, 80))
+    sock.connect.assert_called_once_with((ip, 80))
     sock.send.assert_called_with(b"Date=July 25, 2019")
 
 
@@ -61,5 +61,5 @@ def test_json():
     s = adafruit_requests.Session(pool)
     json_data = {"Date": "July 25, 2019"}
     r = s.post("http://" + host + "/post", json=json_data)
-    sock.connect.assert_called_once_with((host, 80))
+    sock.connect.assert_called_once_with((ip, 80))
     sock.send.assert_called_with(b'{"Date": "July 25, 2019"}')

--- a/tests/post_test.py
+++ b/tests/post_test.py
@@ -13,12 +13,13 @@ headers = "HTTP/1.0 200 OK\r\nContent-Length: {}\r\n\r\n".format(len(encoded)).e
 
 
 def test_method():
-    mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
     sock = mocket.Mocket(headers + encoded)
-    mocket.socket.return_value = sock
+    pool.socket.return_value = sock
 
-    adafruit_requests.set_socket(mocket, mocket.interface)
-    r = adafruit_requests.post("http://" + host + "/post")
+    s = adafruit_requests.Session(pool)
+    r = s.post("http://" + host + "/post")
     sock.connect.assert_called_once_with((host, 80))
     sock.send.assert_has_calls(
         [mock.call(b"POST /post HTTP/1.1\r\n"), mock.call(b"Host: httpbin.org\r\n")]
@@ -26,24 +27,26 @@ def test_method():
 
 
 def test_string():
-    mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
     sock = mocket.Mocket(headers + encoded)
-    mocket.socket.return_value = sock
+    pool.socket.return_value = sock
 
-    adafruit_requests.set_socket(mocket, mocket.interface)
+    s = adafruit_requests.Session(pool)
     data = "31F"
-    r = adafruit_requests.post("http://" + host + "/post", data=data)
+    r = s.post("http://" + host + "/post", data=data)
     sock.connect.assert_called_once_with((host, 80))
     sock.send.assert_called_with(b"31F")
 
 
 def test_json():
-    mocket.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
     sock = mocket.Mocket(headers + encoded)
-    mocket.socket.return_value = sock
+    pool.socket.return_value = sock
 
-    adafruit_requests.set_socket(mocket, mocket.interface)
+    s = adafruit_requests.Session(pool)
     json_data = {"Date": "July 25, 2019"}
-    r = adafruit_requests.post("http://" + host + "/post", json=json_data)
+    r = s.post("http://" + host + "/post", json=json_data)
     sock.connect.assert_called_once_with((host, 80))
     sock.send.assert_called_with(b'{"Date": "July 25, 2019"}')

--- a/tests/protocol_test.py
+++ b/tests/protocol_test.py
@@ -53,7 +53,7 @@ def test_get_http_text():
     s = adafruit_requests.Session(pool)
     r = s.get("http://" + host + path)
 
-    sock.connect.assert_called_once_with((host, 80))
+    sock.connect.assert_called_once_with((ip, 80))
     sock.send.assert_has_calls(
         [
             mock.call(b"GET /testwifi/index.html HTTP/1.1\r\n"),

--- a/tests/protocol_test.py
+++ b/tests/protocol_test.py
@@ -17,10 +17,10 @@ def test_get_https_text():
     adafruit_requests.set_socket(mocket, mocket.interface)
     r = adafruit_requests.get("https://" + host + path)
 
-    sock.connect.assert_called_once_with((host, 443), mocket.interface.TLS_MODE)
+    sock.connect.assert_called_once_with((host, 443))
     sock.send.assert_has_calls(
         [
-            mock.call(b"GET /testwifi/index.html HTTP/1.0\r\n"),
+            mock.call(b"GET /testwifi/index.html HTTP/1.1\r\n"),
             mock.call(b"Host: wifitest.adafruit.com\r\n"),
         ]
     )
@@ -35,10 +35,10 @@ def test_get_http_text():
     adafruit_requests.set_socket(mocket, mocket.interface)
     r = adafruit_requests.get("http://" + host + path)
 
-    sock.connect.assert_called_once_with((ip, 80), mocket.interface.TCP_MODE)
+    sock.connect.assert_called_once_with((host, 80))
     sock.send.assert_has_calls(
         [
-            mock.call(b"GET /testwifi/index.html HTTP/1.0\r\n"),
+            mock.call(b"GET /testwifi/index.html HTTP/1.1\r\n"),
             mock.call(b"Host: wifitest.adafruit.com\r\n"),
         ]
     )

--- a/tests/reuse_test.py
+++ b/tests/reuse_test.py
@@ -1,0 +1,107 @@
+from unittest import mock
+import mocket
+import pytest
+import adafruit_requests
+
+ip = "1.2.3.4"
+host = "wifitest.adafruit.com"
+host2 = "wifitest2.adafruit.com"
+path = "/testwifi/index.html"
+text = b"This is a test of Adafruit WiFi!\r\nIf you can read this, its working :)"
+response = b"HTTP/1.0 200 OK\r\nContent-Length: 70\r\n\r\n" + text
+
+# def test_get_twice():
+#     pool = mocket.MocketPool()
+#     pool.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
+#     sock = mocket.Mocket(response + response)
+#     pool.socket.return_value = sock
+#     ssl = mocket.SSLContext()
+
+#     s = adafruit_requests.Session(pool, ssl)
+#     r = s.get("https://" + host + path)
+
+#     sock.send.assert_has_calls(
+#         [
+#             mock.call(b"GET /testwifi/index.html HTTP/1.1\r\n"),
+#             mock.call(b"Host: wifitest.adafruit.com\r\n"),
+#         ]
+#     )
+#     assert r.text == str(text, "utf-8")
+
+#     r = s.get("https://" + host + path + "2")
+#     sock.send.assert_has_calls(
+#         [
+#             mock.call(b"GET /testwifi/index.html2 HTTP/1.1\r\n"),
+#             mock.call(b"Host: wifitest.adafruit.com\r\n"),
+#         ]
+#     )
+
+#     assert r.text == str(text, "utf-8")
+#     sock.connect.assert_called_once_with((host, 443))
+#     pool.socket.assert_called_once()
+
+
+def test_get_twice_after_second():
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
+    sock = mocket.Mocket(response + response)
+    pool.socket.return_value = sock
+    ssl = mocket.SSLContext()
+
+    s = adafruit_requests.Session(pool, ssl)
+    r = s.get("https://" + host + path)
+
+    sock.send.assert_has_calls(
+        [
+            mock.call(b"GET /testwifi/index.html HTTP/1.1\r\n"),
+            mock.call(b"Host: wifitest.adafruit.com\r\n"),
+        ]
+    )
+
+    r2 = s.get("https://" + host + path + "2")
+    sock.send.assert_has_calls(
+        [
+            mock.call(b"GET /testwifi/index.html2 HTTP/1.1\r\n"),
+            mock.call(b"Host: wifitest.adafruit.com\r\n"),
+        ]
+    )
+    sock.connect.assert_called_once_with((host, 443))
+    pool.socket.assert_called_once()
+
+    with pytest.raises(RuntimeError):
+        r.text == str(text, "utf-8")
+
+
+def test_connect_out_of_memory():
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
+    sock = mocket.Mocket(response)
+    sock2 = mocket.Mocket(response)
+    sock3 = mocket.Mocket(response)
+    pool.socket.side_effect = [sock, sock2, sock3]
+    sock2.connect.side_effect = MemoryError()
+    ssl = mocket.SSLContext()
+
+    s = adafruit_requests.Session(pool, ssl)
+    r = s.get("https://" + host + path)
+
+    sock.send.assert_has_calls(
+        [
+            mock.call(b"GET /testwifi/index.html HTTP/1.1\r\n"),
+            mock.call(b"Host: wifitest.adafruit.com\r\n"),
+        ]
+    )
+    assert r.text == str(text, "utf-8")
+
+    r = s.get("https://" + host2 + path)
+    sock3.send.assert_has_calls(
+        [
+            mock.call(b"GET /testwifi/index.html HTTP/1.1\r\n"),
+            mock.call(b"Host: wifitest2.adafruit.com\r\n"),
+        ]
+    )
+
+    assert r.text == str(text, "utf-8")
+    sock.close.assert_called_once()
+    sock.connect.assert_called_once_with((host, 443))
+    sock3.connect.assert_called_once_with((host2, 443))


### PR DESCRIPTION
Reusing sockets makes sharing memory easier and keeping the connection open will make them faster.

This PR also moves to a model of passing the socket and ssl implementation into `Session` instead of into the module with a function.

json parsing will now happen character-by-character on CircuitPython and lower the peak memory used and the largest allocation size.

It includes legacy compatibility so it *shouldn't* break anything. Corresponding libraries will benefit more from this when they implement `recv_into` so they don't allocate a new buffer every read.

This is draft because I need to:

- [x] Lint it all.