### PR TITLE
Add, test support for chunk extensions

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -212,7 +212,7 @@ class Response:
                 # Consume trailing \r\n for chunks 2+
                 if self._remaining == 0:
                     self._throw_away(2)
-                chunk_header = self._readto(b";", b"\r\n")
+                chunk_header = self._readto(b"\r\n").split(b";", 1)[0]
                 http_chunk_size = int(bytes(chunk_header), 16)
                 if http_chunk_size == 0:
                     self._chunked = False
@@ -253,7 +253,7 @@ class Response:
                 self._throw_away(self._remaining)
             elif self._chunked:
                 while True:
-                    chunk_header = self._readto(b";", b"\r\n")
+                    chunk_header = self._readto(b"\r\n").split(b";", 1)[0]
                     chunk_size = int(bytes(chunk_header), 16)
                     if chunk_size == 0:
                         break

--- a/tests/chunk_test.py
+++ b/tests/chunk_test.py
@@ -57,14 +57,16 @@ def do_test_get_text(extra=b""):
     )
     assert r.text == str(text, "utf-8")
 
+
 def test_get_text():
     do_test_get_text()
 
+
 def test_get_text_extra():
-    do_test_get_text(b';blahblah; blah')
+    do_test_get_text(b";blahblah; blah")
 
 
-def do_test_close_flush(extra=b''):
+def do_test_close_flush(extra=b""):
     """Test that a chunked response can be closed even when the request contents were not accessed."""
     pool = mocket.MocketPool()
     pool.getaddrinfo.return_value = ((None, None, None, None, (ip, 80)),)
@@ -92,8 +94,10 @@ def do_test_close_flush(extra=b''):
 
     r.close()
 
+
 def test_close_flush():
     do_test_close_flush()
 
+
 def test_close_flush_extra():
-    do_test_close_flush(b';blahblah; blah')
+    do_test_close_flush(b";blahblah; blah")


### PR DESCRIPTION
The chunk line is read up to the terminating "\r\n", then any extensions are ignored by only using the string up to the first ";" (if any) when determining the length of the chunk.

Resources:
https://tools.ietf.org/html/rfc7230#section-4.1.1
https://www.boost.org/doc/libs/1_74_0/libs/beast/doc/html/beast/using_http/chunked_encoding.html

Thanks to @anecdata for asking on Discord why ";" was getting special treatment, leading to this investigation.  We don't know of a specific URL or service that is affected by this bug.