### PR TITLE
Don't use https://wifitest.adafruit.com/testwifi/index.html

### DIFF
--- a/examples/requests_https_cpython.py
+++ b/examples/requests_https_cpython.py
@@ -5,7 +5,7 @@ import adafruit_requests as requests
 
 https = requests.Session(socket, ssl.create_default_context())
 
-TEXT_URL = "https://wifitest.adafruit.com/testwifi/index.html"
+TEXT_URL = "https://httpbin.org/get"
 JSON_GET_URL = "https://httpbin.org/get"
 JSON_POST_URL = "https://httpbin.org/post"
 


### PR DESCRIPTION
https://wifitest.adafruit.com/testwifi/index.html doesn't work, only http:// does, so use https://httpbin.org/get fetched as text for now.

The actual fetch is currently commented out, but if uncommented, it would not work.