### PR TITLE
One more case for _buffer_split0

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -274,7 +274,7 @@ class Response:
                 self._throw_away(self._remaining)
             elif self._chunked:
                 while True:
-                    chunk_header = self._readto(b"\r\n").split(b";", 1)[0]
+                    chunk_header = _buffer_split0(self._readto(b"\r\n"), b";")
                     chunk_size = int(bytes(chunk_header), 16)
                     if chunk_size == 0:
                         break


### PR DESCRIPTION
There was a second case where a bytearray was being split. We need to use @jepler's fix there as well. 

Without this fix, when you would reuse your requests object you'd get an error.

```python
response = requests.get("https://io.adafruit.com/api/v2/time/seconds")

response = requests.get("https://io.adafruit.com/api/v2/time/seconds")
_last_response: <Response object at 3f7b3b20>
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/adafruit_requests.py", line 613, in get
  File "/lib/adafruit_requests.py", line 569, in request
  File "/lib/adafruit_requests.py", line 277, in close
AttributeError: 'bytearray' object has no attribute 'split'
```