### PR TITLE
Fix examples for ESP32SPI + SSL socket

### DIFF
--- a/examples/requests_advanced.py
+++ b/examples/requests_advanced.py
@@ -39,7 +39,7 @@ print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
 
 # Initialize a requests object with a socket and esp32spi interface
 socket.set_interface(esp)
-requests.set_socket(socket)
+requests.set_socket(socket, esp)
 
 JSON_GET_URL = "http://httpbin.org/get"
 
@@ -58,9 +58,6 @@ print("-" * 60)
 # Read Response's HTTP status code
 print("Response HTTP Status Code: ", response.status_code)
 print("-" * 60)
-
-# Read Response, as raw bytes instead of pretty text
-print("Raw Response: ", response.content)
 
 # Close, delete and collect the response data
 response.close()

--- a/examples/requests_simpletest.py
+++ b/examples/requests_simpletest.py
@@ -40,7 +40,7 @@ print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
 
 # Initialize a requests object with a socket and esp32spi interface
 socket.set_interface(esp)
-requests.set_socket(socket)
+requests.set_socket(socket, esp)
 
 TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
 JSON_GET_URL = "http://httpbin.org/get"


### PR DESCRIPTION
Addresses https://github.com/adafruit/Adafruit_CircuitPython_Requests/issues/57 and fixes `RuntimeError: Cannot access content after getting text or json` error in `examples/requests_advanced.py`