### PR TITLE
Catch OSError to avoid socket leak

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -560,7 +560,7 @@ class Session:
             ok = True
             try:
                 self._send_request(socket, host, method, path, headers, data, json)
-            except _SendFailed:
+            except (_SendFailed, OSError):
                 ok = False
             if ok:
                 # Read the H of "HTTP/1.1" to make sure the socket is alive. send can appear to work


### PR DESCRIPTION
Catch `OSError` along with `_SendFailed` to avoid `RuntimeError: Out of sockets` caused by `OSError: Failed SSL handshake`

Background:
[https://github.com/adafruit/Adafruit_CircuitPython_Requests/issues/63#issuecomment-771650173](https://github.com/adafruit/Adafruit_CircuitPython_Requests/issues/63#issuecomment-771650173)

This should address #67 