### PR TITLE
Catch recv-into exception to prevent Out of sockets

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -569,7 +569,10 @@ class Session:
                     result = socket.recv(1)
                 else:
                     result = bytearray(1)
-                    socket.recv_into(result)
+                    try:
+                        socket.recv_into(result)
+                    except OSError:
+                        pass
                 if result == b"H":
                     # Things seem to be ok so break with socket set.
                     break

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -580,7 +580,7 @@ class Session:
             socket = None
 
         if not socket:
-            raise OutOfRetries()
+            raise OutOfRetries("Repeated socket failures")
 
         resp = Response(socket, self)  # our response
         if "location" in resp.headers and 300 <= resp.status_code <= 399:


### PR DESCRIPTION
An `ETIMEDOUT` exception occurring on a `socket.recv_into` call in a Session request would leave the socket open, and after two occurrences, would get `RuntimeError: Out of sockets` and require a microcontroller reset.
```
Traceback (most recent call last):
  File "code.py", line 675, in http_get
  File "/lib/adafruit_requests.py", line 595, in get
  File "/lib/adafruit_requests.py", line 572, in request
OSError: [Errno 116] ETIMEDOUT
# ...
Traceback (most recent call last):
  File "code.py", line 675, in http_get
  File "/lib/adafruit_requests.py", line 595, in get
  File "/lib/adafruit_requests.py", line 572, in request
OSError: [Errno 116] ETIMEDOUT
# ...
Traceback (most recent call last):  
  File "code.py", line 675, in http_get
  File "adafruit_requests.py", line 595, in get
  File "adafruit_requests.py", line 559, in request
  File "adafruit_requests.py", line 436, in _get_socket
  File "adafruit_requests.py", line 433, in _get_socket
RuntimeError: Out of sockets
```
After this change, if the failure persists, it will raise an `OutOfRetries: ` exception, just as in the case of persistent `_send_request` failures.