### PR TITLE
Remove last arg from .socket() call

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -424,9 +424,7 @@ class Session:
             retry_count += 1
 
             try:
-                sock = self._socket_pool.socket(
-                    addr_info[0], addr_info[1], addr_info[2]
-                )
+                sock = self._socket_pool.socket(addr_info[0], addr_info[1])
             except OSError:
                 continue
             except RuntimeError:


### PR DESCRIPTION
- Fixes #81.

`SocketPool.socket()` only takes two arguments, but three were being passed. Because of https://github.com/adafruit/circuitpython/pull/5439, this went undetected until recently.

Tagging @tannewt for interest.