### PR TITLE
Fix importing `adafruit_requests` in CPython

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Versions
       run: |
         python3 --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,70 +10,70 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: Translate Repo Name For Build Tools filename_prefix
-        id: repo-name
-        run: |
-          echo ::set-output name=repo-name::$(
-          echo ${{ github.repository }} |
-          awk -F '\/' '{ print tolower($2) }' |
-          tr '_' '-'
-          )
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-      - name: Versions
-        run: |
-          python3 --version
-      - name: Checkout Current Repo
-        uses: actions/checkout@v1
-        with:
-          submodules: true
-      - name: Checkout tools repo
-        uses: actions/checkout@v2
-        with:
-          repository: adafruit/actions-ci-circuitpython-libs
-          path: actions-ci
-      - name: Install dependencies
-        # (e.g. - apt-get: gettext, etc; pip: circuitpython-build-tools, requirements.txt; etc.)
-        run: |
-          source actions-ci/install.sh
-      - name: Pip install Sphinx, pre-commit
-        run: |
-          pip install --force-reinstall Sphinx sphinx-rtd-theme pre-commit
-      - name: Library version
-        run: git describe --dirty --always --tags
-      - name: Pre-commit hooks
-        run: |
-          pre-commit run --all-files
-      - name: Build assets
-        run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
-      - name: Archive bundles
-        uses: actions/upload-artifact@v2
-        with:
-          name: bundles
-          path: ${{ github.workspace }}/bundles/
-      - name: Build docs
-        working-directory: docs
-        run: sphinx-build -E -W -b html . _build/html
-      - name: Check For setup.py
-        id: need-pypi
-        run: |
-          echo ::set-output name=setup-py::$( find . -wholename './setup.py' )
-      - name: Build Python package
-        if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
-        run: |
-          pip install --upgrade setuptools wheel twine readme_renderer testresources
-          python setup.py sdist
-          python setup.py bdist_wheel --universal
-          twine check dist/*
-      - name: Test Python package
-        run: |
-          pip install tox==3.24.5
-          tox
-      - name: Setup problem matchers
-        uses: adafruit/circuitpython-action-library-ci-problem-matchers@v1
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - name: Translate Repo Name For Build Tools filename_prefix
+      id: repo-name
+      run: |
+        echo ::set-output name=repo-name::$(
+        echo ${{ github.repository }} |
+        awk -F '\/' '{ print tolower($2) }' |
+        tr '_' '-'
+        )
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Versions
+      run: |
+        python3 --version
+    - name: Checkout Current Repo
+      uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Checkout tools repo
+      uses: actions/checkout@v2
+      with:
+        repository: adafruit/actions-ci-circuitpython-libs
+        path: actions-ci
+    - name: Install dependencies
+      # (e.g. - apt-get: gettext, etc; pip: circuitpython-build-tools, requirements.txt; etc.)
+      run: |
+        source actions-ci/install.sh
+    - name: Pip install Sphinx, pre-commit
+      run: |
+        pip install --force-reinstall Sphinx sphinx-rtd-theme pre-commit
+    - name: Library version
+      run: git describe --dirty --always --tags
+    - name: Pre-commit hooks
+      run: |
+        pre-commit run --all-files
+    - name: Build assets
+      run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
+    - name: Archive bundles
+      uses: actions/upload-artifact@v2
+      with:
+        name: bundles
+        path: ${{ github.workspace }}/bundles/
+    - name: Build docs
+      working-directory: docs
+      run: sphinx-build -E -W -b html . _build/html
+    - name: Check For setup.py
+      id: need-pypi
+      run: |
+        echo ::set-output name=setup-py::$( find . -wholename './setup.py' )
+    - name: Build Python package
+      if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
+      run: |
+        pip install --upgrade setuptools wheel twine readme_renderer testresources
+        python setup.py sdist
+        python setup.py bdist_wheel --universal
+        twine check dist/*
+    - name: Test Python package
+      run: |
+        pip install tox==3.24.5
+        tox
+    - name: Setup problem matchers
+      uses: adafruit/circuitpython-action-library-ci-problem-matchers@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,66 +10,70 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-    - name: Translate Repo Name For Build Tools filename_prefix
-      id: repo-name
-      run: |
-        echo ::set-output name=repo-name::$(
-        echo ${{ github.repository }} |
-        awk -F '\/' '{ print tolower($2) }' |
-        tr '_' '-'
-        )
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Versions
-      run: |
-        python3 --version
-    - name: Checkout Current Repo
-      uses: actions/checkout@v1
-      with:
-        submodules: true
-    - name: Checkout tools repo
-      uses: actions/checkout@v2
-      with:
-        repository: adafruit/actions-ci-circuitpython-libs
-        path: actions-ci
-    - name: Install dependencies
-      # (e.g. - apt-get: gettext, etc; pip: circuitpython-build-tools, requirements.txt; etc.)
-      run: |
-        source actions-ci/install.sh
-    - name: Pip install Sphinx, pre-commit
-      run: |
-        pip install --force-reinstall Sphinx sphinx-rtd-theme pre-commit
-    - name: Library version
-      run: git describe --dirty --always --tags
-    - name: Pre-commit hooks
-      run: |
-        pre-commit run --all-files
-    - name: Build assets
-      run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
-    - name: Archive bundles
-      uses: actions/upload-artifact@v2
-      with:
-        name: bundles
-        path: ${{ github.workspace }}/bundles/
-    - name: Build docs
-      working-directory: docs
-      run: sphinx-build -E -W -b html . _build/html
-    - name: Check For setup.py
-      id: need-pypi
-      run: |
-        echo ::set-output name=setup-py::$( find . -wholename './setup.py' )
-    - name: Build Python package
-      if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
-      run: |
-        pip install --upgrade setuptools wheel twine readme_renderer testresources
-        python setup.py sdist
-        python setup.py bdist_wheel --universal
-        twine check dist/*
-    - name: Setup problem matchers
-      uses: adafruit/circuitpython-action-library-ci-problem-matchers@v1
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Translate Repo Name For Build Tools filename_prefix
+        id: repo-name
+        run: |
+          echo ::set-output name=repo-name::$(
+          echo ${{ github.repository }} |
+          awk -F '\/' '{ print tolower($2) }' |
+          tr '_' '-'
+          )
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Versions
+        run: |
+          python3 --version
+      - name: Checkout Current Repo
+        uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: Checkout tools repo
+        uses: actions/checkout@v2
+        with:
+          repository: adafruit/actions-ci-circuitpython-libs
+          path: actions-ci
+      - name: Install dependencies
+        # (e.g. - apt-get: gettext, etc; pip: circuitpython-build-tools, requirements.txt; etc.)
+        run: |
+          source actions-ci/install.sh
+      - name: Pip install Sphinx, pre-commit
+        run: |
+          pip install --force-reinstall Sphinx sphinx-rtd-theme pre-commit
+      - name: Library version
+        run: git describe --dirty --always --tags
+      - name: Pre-commit hooks
+        run: |
+          pre-commit run --all-files
+      - name: Build assets
+        run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
+      - name: Archive bundles
+        uses: actions/upload-artifact@v2
+        with:
+          name: bundles
+          path: ${{ github.workspace }}/bundles/
+      - name: Build docs
+        working-directory: docs
+        run: sphinx-build -E -W -b html . _build/html
+      - name: Check For setup.py
+        id: need-pypi
+        run: |
+          echo ::set-output name=setup-py::$( find . -wholename './setup.py' )
+      - name: Build Python package
+        if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
+        run: |
+          pip install --upgrade setuptools wheel twine readme_renderer testresources
+          python setup.py sdist
+          python setup.py bdist_wheel --universal
+          twine check dist/*
+      - name: Test Python package
+        run: |
+          pip install tox==3.24.5
+          tox
+      - name: Setup problem matchers
+        uses: adafruit/circuitpython-action-library-ci-problem-matchers@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
       uses: actions/setup-python@v1
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     - name: Install dependencies
       if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 *.mpy
 .idea
+.vscode
 __pycache__
 _build
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 _build
 *.pyc
 .env
+.tox
 bundles
 *.DS_Store
 .eggs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@
 version: 2
 
 python:
-  version: "3.7"
+  version: "3.8"
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -49,8 +49,7 @@ if sys.implementation.name == "circuitpython":
 else:
     from ssl import SSLContext
     from types import ModuleType, TracebackType
-    from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
-    from typing_extensions import Protocol
+    from typing import Any, Dict, List, Optional, Protocol, Tuple, Type, Union, cast
 
     # Based on https://github.com/python/typeshed/blob/master/stdlib/_socket.pyi
     class CommonSocketType(Protocol):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["adafruit_esp32spi", "adafruit_wiznet5k", "adafruit_fona"]
+# autodoc_mock_imports = ["digitalio", "busio"]
 
 
 intersphinx_mapping = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
+typing-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
-typing-extensions

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
+    python_requires=">=3.8",
     install_requires=["Adafruit-Blinka", "typing-extensions"],
     # Choose your license
     license="MIT",
@@ -44,8 +45,7 @@ setup(
         "Topic :: System :: Hardware",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.8",
     ],
     # What does your project relate to?
     keywords="adafruit blinka circuitpython micropython requests requests, networking",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka"],
+    install_requires=["Adafruit-Blinka", "typing-extensions"],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
     python_requires=">=3.8",
-    install_requires=["Adafruit-Blinka", "typing-extensions"],
+    install_requires=["Adafruit-Blinka"],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2022 Kevin Conley
+#
+# SPDX-License-Identifier: MIT
+
+[tox]
+envlist = py37
+
+[testenv]
+changedir = {toxinidir}/tests
+deps = pytest==6.2.5
+commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 [tox]
-envlist = py37
+envlist = py38
 
 [testenv]
 changedir = {toxinidir}/tests


### PR DESCRIPTION
This PR fixes importing `adafruit_requests` in CPython by replacing the imports of various classes from `adafruit_esp32spi`, `adafruit_wiznet5k`, etc. (which weren't specified as requirements of `adafruit_requests` and thus caused importing `adafruit_requests` to fail due to not being available) with [protocols](https://mypy.readthedocs.io/en/stable/protocols.html) that describe the common structure of those types.

To help prevent the use of `adafruit_requests` in CPython from breaking in the future, this PR also adds a step to the Build CI job which uses tox to build the package and run its tests in a virtual environment.

I also tested the changes to `adafruit_requests.py` in CircuitPython by copying the file to the `lib/` folder of my MagTag device running the [COVID tracking project](https://learn.adafruit.com/magtag-covid-tracking-project-iot-display) and verifying that the display showed the COVID stats as expected (although note that project's data source [has stopped reporting new data since March 7, 2021](https://covidtracking.com/analysis-updates/giving-thanks-and-looking-ahead-our-data-collection-work-is-done)).

Fixes #93.