### PR TITLE
fallback types

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -65,7 +65,11 @@ try:
     InterfaceType = TypeVar("InterfaceType", ESP_SPIcontrol, WIZNET5K, FONA)
 
 except ImportError:
-    pass
+    # pylint: disable=invalid-name
+    SocketType = None
+    SocketpoolModuleType = None
+    SSLContextType = None
+    InterfaceType = None
 
 # CircuitPython 6.0 does not have the bytearray.split method.
 # This function emulates buf.split(needle)[0], which is the functionality


### PR DESCRIPTION
If certain imports used for typing are missing, these custom TypeVars can end up not being defined which causes sphinx to fail to build with them ex: https://github.com/adafruit/Adafruit_CircuitPython_FunHouse/pull/28/checks

This change provides minimal fallbacks for those types so that sphinx build will complete in this case.