### PR TITLE
raise error indicating gzipped data

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -435,7 +435,10 @@ class Response:
                 return self._cached
             raise RuntimeError("Cannot access text after getting content or json")
 
-        if self.headers["content-encoding"] == "gzip":
+        if (
+            "content-encoding" in self.headers
+            and self.headers["content-encoding"] == "gzip"
+        ):
             raise ValueError(
                 "Content-encoding is gzip, data cannot be accessed as json or text. "
                 "Use content property to access raw bytes."
@@ -456,7 +459,10 @@ class Response:
         if not self._raw:
             self._raw = _RawResponse(self)
 
-        if self.headers["content-encoding"] == "gzip":
+        if (
+            "content-encoding" in self.headers
+            and self.headers["content-encoding"] == "gzip"
+        ):
             raise ValueError(
                 "Content-encoding is gzip, data cannot be accessed as json or text. "
                 "Use content property to access raw bytes."

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -434,6 +434,12 @@ class Response:
             if isinstance(self._cached, str):
                 return self._cached
             raise RuntimeError("Cannot access text after getting content or json")
+
+        if self.headers["content-encoding"] == "gzip":
+            raise ValueError(
+                "Content-encoding is gzip, data cannot be accessed as json or text. "
+                "Use content property to access raw bytes."
+            )
         self._cached = str(self.content, self.encoding)
         return self._cached
 
@@ -450,6 +456,11 @@ class Response:
         if not self._raw:
             self._raw = _RawResponse(self)
 
+        if self.headers["content-encoding"] == "gzip":
+            raise ValueError(
+                "Content-encoding is gzip, data cannot be accessed as json or text. "
+                "Use content property to access raw bytes."
+            )
         try:
             obj = json.load(self._raw)
         except OSError:


### PR DESCRIPTION
This change presents a short term improvement of the error messages that arise from fetching GZipped data from an API. The message has been changed to state the exact cause of the problem and let the user know the way to access the raw data.

Tested successfully on Feather TFT ESP32-S2 and CPython on Linux using this code (with slightly modified initialization on the Feather for the circuitpython way of setup):
```py
https = requests.Session(socket, ssl.create_default_context())

JSON_GET_URL = "https://analytics.usa.gov/data/live/realtime.json"

print("Fetching JSON data from %s" % JSON_GET_URL)
response = https.get(JSON_GET_URL)
print("-" * 40)

print("JSON Response: ", response.text)
print("-" * 40)

# print("JSON Response: ", response.json())
# print("-" * 40)
```
current version output (on CPython, it's very similar in CircuitPython but the error type is more general ValueError):
```
Fetching JSON data from https://analytics.usa.gov/data/live/realtime.json
----------------------------------------
Traceback (most recent call last):
  File "/home/timc/repos/circuitpython/Adafruit_CircuitPython_Requests/examples/gov_requests_https_cpython.py", line 19, in <module>
    print("JSON Response: ", response.text)
  File "/home/timc/repos/circuitpython/Adafruit_CircuitPython_Requests/adafruit_requests.py", line 437, in text
    self._cached = str(self.content, self.encoding)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte
```

new output:
```
Fetching JSON data from https://analytics.usa.gov/data/live/realtime.json
----------------------------------------
Traceback (most recent call last):
  File "/home/timc/repos/circuitpython/Adafruit_CircuitPython_Requests/examples/gov_requests_https_cpython.py", line 19, in <module>
    print("JSON Response: ", response.text)
  File "/home/timc/repos/circuitpython/Adafruit_CircuitPython_Requests/adafruit_requests.py", line 439, in text
    raise ValueError(
ValueError: Content-encoding is gzip, data cannot be accessed as json or text. Use content property to access raw bytes.
```

I also verified that catching the exception does allow user code to successfully access the raw data:
```py
try:
    print("JSON Response: ", response.json())
    print("-" * 40)
except ValueError:
    stream = io.BytesIO(response.content)
    field = pyflate.RBitfield(stream)
    magic = field.readbits(16)
    if magic == 0x1f8b: # GZip
        out = pyflate.gzip_main(field)

    json_data = json.loads(out)
    print(json_data)
    print("Active Visitors {}".format(json_data["data"][0]["active_visitors"]))
```
