### PR TITLE
Remove pre 7.0 compatibility; other cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
 -   repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 22.1.0
     hooks:
     - id: black
 -   repo: https://github.com/fsfe/reuse-tool

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -39,6 +39,8 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Requests.git"
 import errno
 import sys
 
+import json as json_module
+
 if sys.implementation.name == "circuitpython":
 
     def cast(_t, value):
@@ -404,9 +406,6 @@ class Response:
 
     def json(self) -> Any:
         """The HTTP content, parsed into a json dictionary"""
-        # pylint: disable=import-outside-toplevel
-        import json
-
         # The cached JSON will be a list or dictionary.
         if self._cached:
             if isinstance(self._cached, (list, dict)):
@@ -417,7 +416,7 @@ class Response:
 
         self._validate_not_gzip()
 
-        obj = json.load(self._raw)
+        obj = json_module.load(self._raw)
         if not self._cached:
             self._cached = obj
         self.close()
@@ -588,10 +587,7 @@ class Session:
             self._send(socket, b"\r\n")
         if json is not None:
             assert data is None
-            # pylint: disable=import-outside-toplevel
-            import json
-
-            data = json.dumps(json)
+            data = json_module.dumps(json)
             self._send(socket, b"Content-Type: application/json\r\n")
         if data:
             if isinstance(data, dict):

--- a/tests/legacy_mocket.py
+++ b/tests/legacy_mocket.py
@@ -15,7 +15,7 @@ socket = mock.Mock()
 
 
 class Mocket:  # pylint: disable=too-few-public-methods
-    """  Mock Socket """
+    """Mock Socket"""
 
     def __init__(self, response):
         self.settimeout = mock.Mock()

--- a/tests/mocket.py
+++ b/tests/mocket.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 
 class MocketPool:  # pylint: disable=too-few-public-methods
-    """ Mock SocketPool """
+    """Mock SocketPool"""
 
     SOCK_STREAM = 0
 
@@ -18,7 +18,7 @@ class MocketPool:  # pylint: disable=too-few-public-methods
 
 
 class Mocket:  # pylint: disable=too-few-public-methods
-    """ Mock Socket """
+    """Mock Socket"""
 
     def __init__(self, response):
         self.settimeout = mock.Mock()
@@ -62,7 +62,7 @@ class Mocket:  # pylint: disable=too-few-public-methods
 
 
 class SSLContext:  # pylint: disable=too-few-public-methods
-    """ Mock SSL Context """
+    """Mock SSL Context"""
 
     def __init__(self):
         self.wrap_socket = mock.Mock(side_effect=self._wrap_socket)


### PR DESCRIPTION
Simplify and shorten the current code. I will have a further PR later that changes a bunch of thrown exceptions to allow for easier error handling.

- CircuitPython 7 supports `split()` on bytes and bytearrays. Remove hand-coded routines no longer needed.
- CircuitPython 6 supports streaming `json` decoding. Remove workaround for 5.x non-streaming decoding.
- Refactor the duplicated check for gzip content.

_Please_ test with your own wifi code - thanks. I tested this with the simple wifi testing code, and with the Google calendar example, but not with other examples.