### PR TITLE
Proposed solution for Issue #104: multiple cookies

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -358,7 +358,10 @@ class Response:
                     self._remaining = int(content)
                 if title == "transfer-encoding":
                     self._chunked = content.strip().lower() == "chunked"
-                self._headers[title] = content
+                if title == "set-cookie" and title in self._headers:
+                    self._headers[title] = self._headers[title] + ", " + content
+                else:
+                    self._headers[title] = content
 
     def _validate_not_gzip(self) -> None:
         """gzip encoding is not supported. Raise an exception if found."""


### PR DESCRIPTION
Patch so that the _parse_headers function handles multiple cookies by appending them, separated by a comma and space. This mimics the behaviour of Python requests when it comes to response.headers['set-cookie'] and response.headers.items(). 

Currently this function just writes over any previous cookie, leaving only the last one. That doesn't allow it to work with some APIs, e.g. the Growatt solar API that I've been working on.

Thrilled to be submitting my first public pull request. Thanks to @askpatrickw and @tekktrik for their encouragement. 

Hope I've sent it to the right place this time!