### PR TITLE
When sending data get the bytes length not the string length

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -609,13 +609,12 @@ class Session:
                 for k in data:
                     _post_data = "{}&{}={}".format(_post_data, k, data[k])
                 data = _post_data[1:]
+            if isinstance(data, str):
+                data = bytes(data, "utf-8")
             self._send(socket, b"Content-Length: %d\r\n" % len(data))
         self._send(socket, b"\r\n")
         if data:
-            if isinstance(data, bytearray):
-                self._send(socket, bytes(data))
-            else:
-                self._send(socket, bytes(data, "utf-8"))
+            self._send(socket, bytes(data))
 
     # pylint: disable=too-many-branches, too-many-statements, unused-argument, too-many-arguments, too-many-locals
     def request(


### PR DESCRIPTION
This always converts `data` from string to bytes *before* getting the length.
Otherwise data that contains UTF-8 characters gets truncated if the server follows the content length.
`data` is still converted to `bytes` if not a string. (Is it necessary ?)

This was reported in the support forums by testing with pushover.net (using the desktop in-browser interface to receive the messages).

```py
import ssl
import time
import wifi
import socketpool
import adafruit_requests
from secrets import secrets

# URLs
PUSHOVER_JSON_URL = 'https://api.pushover.net/1/messages.json'

wifi.radio.connect(secrets['ssid'], secrets['password'])
pool = socketpool.SocketPool(wifi.radio)
requests = adafruit_requests.Session(pool, ssl.create_default_context())

data = {
    'token': secrets['pushover_app_token'],
    'user': secrets['pushover_user_key'],
    'title': "Test Requests Content Length",
    'message': 'The ñ temperature is, 32°C...',
}
with requests.post(PUSHOVER_JSON_URL, data=data) as response:
    print("API Response: ", response.text)
```
`ñ` and `°` are encoded with 2 bytes.
```py
>>> len('The ñ temperature is, 32°C...')
29
>>> len('The ñ temperature is, 32°C...'.encode())
31
```
This is the result in the browser, before the fix is the bottom one. 2 characters are missing.

<img width="286" alt="Capture d’écran 2022-08-03 à 14 40 40" src="https://user-images.githubusercontent.com/6160205/182611593-cc4191fa-727a-47c6-966a-4f7efbb819af.png">

Note that what gets cut depends on the order in which the parameters end up, dicts are not ordered in CP so the loop goes through them in no particular order. In this example it's the message that ends up last.

I only tested that, and some of the examples from this repository.