### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -117,7 +117,6 @@ else:
     ):  # pylint: disable=too-many-ancestors
         """Describes the structure every modern CircuitPython socket type must have."""
 
-
     class StandardPythonSocketType(
         CommonSocketType, SupportsRecvInto, SupportsRecvWithFlags, Protocol
     ):

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -64,15 +64,12 @@ else:
         def send(self, data: bytes, flags: int = ...) -> None:
             """Send data to the socket. The meaning of the optional flags kwarg is
             implementation-specific."""
-            ...
 
         def settimeout(self, value: Optional[float]) -> None:
             """Set a timeout on blocking socket operations."""
-            ...
 
         def close(self) -> None:
             """Close the socket."""
-            ...
 
     class CommonCircuitPythonSocketType(CommonSocketType, Protocol):
         """Describes the common structure every CircuitPython socket type must have."""
@@ -84,7 +81,6 @@ else:
         ) -> None:
             """Connect to a remote socket at the provided (host, port) address. The conntype
             kwarg optionally may indicate SSL or not, depending on the underlying interface."""
-            ...
 
     class LegacyCircuitPythonSocketType(CommonCircuitPythonSocketType, Protocol):
         """Describes the structure a legacy CircuitPython socket type must have."""
@@ -93,7 +89,6 @@ else:
             """Receive data from the socket. The return value is a bytes object representing
             the data received. The maximum amount of data to be received at once is specified
             by bufsize."""
-            ...
 
     class SupportsRecvWithFlags(Protocol):
         """Describes a type that posseses a socket recv() method supporting the flags kwarg."""
@@ -102,7 +97,6 @@ else:
             """Receive data from the socket. The return value is a bytes object representing
             the data received. The maximum amount of data to be received at once is specified
             by bufsize. The meaning of the optional flags kwarg is implementation-specific."""
-            ...
 
     class SupportsRecvInto(Protocol):
         """Describes a type that possesses a socket recv_into() method."""
@@ -114,7 +108,6 @@ else:
             buffer. If nbytes is not specified (or 0), receive up to the size available in the
             given buffer. The meaning of the optional flags kwarg is implementation-specific.
             Returns the number of bytes received."""
-            ...
 
     class CircuitPythonSocketType(
         CommonCircuitPythonSocketType,
@@ -124,7 +117,6 @@ else:
     ):  # pylint: disable=too-many-ancestors
         """Describes the structure every modern CircuitPython socket type must have."""
 
-        ...
 
     class StandardPythonSocketType(
         CommonSocketType, SupportsRecvInto, SupportsRecvWithFlags, Protocol
@@ -133,7 +125,6 @@ else:
 
         def connect(self, address: Union[Tuple[Any, ...], str, bytes]) -> None:
             """Connect to a remote socket at the provided address."""
-            ...
 
     SocketType = Union[
         LegacyCircuitPythonSocketType,
@@ -149,7 +140,6 @@ else:
         @property
         def TLS_MODE(self) -> int:  # pylint: disable=invalid-name
             """Constant representing that a socket's connection mode is TLS."""
-            ...
 
     SSLContextType = Union[SSLContext, "_FakeSSLContext"]
 


### PR DESCRIPTION
Fixes the following `pylint` errors:

```

************* Module adafruit_requests
Error: adafruit_requests.py:67:12: W2301: Unnecessary ellipsis constant (unnecessary-ellipsis)
Error: adafruit_requests.py:71:12: W2301: Unnecessary ellipsis constant (unnecessary-ellipsis)
Error: adafruit_requests.py:75:12: W2301: Unnecessary ellipsis constant (unnecessary-ellipsis)
Error: adafruit_requests.py:87:12: W2301: Unnecessary ellipsis constant (unnecessary-ellipsis)
Error: adafruit_requests.py:96:12: W2301: Unnecessary ellipsis constant (unnecessary-ellipsis)
Error: adafruit_requests.py:105:12: W2301: Unnecessary ellipsis constant (unnecessary-ellipsis)
Error: adafruit_requests.py:117:12: W2301: Unnecessary ellipsis constant (unnecessary-ellipsis)
Error: adafruit_requests.py:127:8: W2301: Unnecessary ellipsis constant (unnecessary-ellipsis)
Error: adafruit_requests.py:136:12: W2301: Unnecessary ellipsis constant (unnecessary-ellipsis)
Error: adafruit_requests.py:152:12: W2301: Unnecessary ellipsis constant (unnecessary-ellipsis)
```