### PR TITLE
Update Requests Discord API example to use settings.toml

### DIFF
--- a/examples/requests_api_discord.py
+++ b/examples/requests_api_discord.py
@@ -1,8 +1,8 @@
-# SPDX-FileCopyrightText: 2022 DJDevon3 for Adafruit Industries
+# SPDX-FileCopyrightText: 2023 DJDevon3
 # SPDX-License-Identifier: MIT
-# Coded for Circuit Python 8.0
-"""DJDevon3 Adafruit Feather ESP32-S2 Discord_API_Example"""
-import gc
+# Coded for Circuit Python 8.2
+# DJDevon3 Adafruit Feather ESP32-S3 Discord API Example
+import os
 import time
 import ssl
 import json
@@ -14,36 +14,38 @@ import adafruit_requests
 # WEB SCRAPE authorization key required. Visit URL below.
 # Learn how: https://github.com/lorenz234/Discord-Data-Scraping
 
-# Ensure this is in secrets.py or .env
-# "Discord_Authorization": "Discord Authorization from browser console"
+# Ensure this is in settings.toml
+# "Discord_Authorization": "Request Header Auth here"
+
+# Uses settings.toml for credentials
+ssid = os.getenv("CIRCUITPY_WIFI_SSID")
+appw = os.getenv("CIRCUITPY_WIFI_PASSWORD")
+Discord_Auth = os.getenv("Discord_Authorization")
 
 # Initialize WiFi Pool (There can be only 1 pool & top of script)
 pool = socketpool.SocketPool(wifi.radio)
 
-# Time between API refreshes
+# API Polling Rate
 # 900 = 15 mins, 1800 = 30 mins, 3600 = 1 hour
 sleep_time = 900
 
-try:
-    from secrets import secrets
-except ImportError:
-    print("Secrets File Import Error")
-    raise
+# Converts seconds to human readable minutes/hours/days
+def time_calc(input_time):  # input_time in seconds
+    if input_time < 60:
+        sleep_int = input_time
+        time_output = f"{sleep_int:.0f} seconds"
+    elif 60 <= input_time < 3600:
+        sleep_int = input_time / 60
+        time_output = f"{sleep_int:.0f} minutes"
+    elif 3600 <= input_time < 86400:
+        sleep_int = input_time / 60 / 60
+        time_output = f"{sleep_int:.1f} hours"
+    else:
+        sleep_int = input_time / 60 / 60 / 24
+        time_output = f"{sleep_int:.1f} days"
+    return time_output
 
-if sleep_time < 60:
-    sleep_time_conversion = "seconds"
-    sleep_int = sleep_time
-elif 60 <= sleep_time < 3600:
-    sleep_int = sleep_time / 60
-    sleep_time_conversion = "minutes"
-elif 3600 <= sleep_time < 86400:
-    sleep_int = sleep_time / 60 / 60
-    sleep_time_conversion = "hours"
-else:
-    sleep_int = sleep_time / 60 / 60 / 24
-    sleep_time_conversion = "days"
-
-discord_header = {"Authorization": "" + secrets["Discord_Authorization"]}
+discord_header = {"Authorization": "" + Discord_Auth}
 ADA_SOURCE = (
     "https://discord.com/api/v10/guilds/"
     + "327254708534116352"  # Adafruit Discord ID
@@ -56,21 +58,20 @@ print("Connecting to WiFi...")
 requests = adafruit_requests.Session(pool, ssl.create_default_context())
 while not wifi.radio.ipv4_address:
     try:
-        wifi.radio.connect(secrets["ssid"], secrets["password"])
+        wifi.radio.connect(ssid, appw)
     except ConnectionError as e:
         print("Connection Error:", e)
         print("Retrying in 10 seconds")
     time.sleep(10)
-    gc.collect()
-print("Connected!\n")
+print("Connected!✅")
 
 while True:
     try:
         print(
-            "\nAttempting to GET DISCORD PREVIEW!"
+            "\nAttempting to GET Discord Data!"
         )  # --------------------------------
-        # Print Request to Serial
-        debug_request = False  # Set true to see full request
+        # STREAMER WARNING this will show your credentials!
+        debug_request = False  # Set True to see full request
         if debug_request:
             print("Full API GET URL: ", ADA_SOURCE)
         print("===============================")
@@ -81,13 +82,13 @@ while True:
             print("Retrying in 10 seconds")
 
         # Print Full JSON to Serial
-        discord_debug_response = False  # Change to true to see full response
+        discord_debug_response = False  # Set True to see full response
         if discord_debug_response:
             ada_discord_dump_object = json.dumps(ada_res)
             print("JSON Dump: ", ada_discord_dump_object)
 
         # Print keys to Serial
-        discord_debug_keys = True  # Set to True to print Serial data
+        discord_debug_keys = True  # Set True to print Serial data
         if discord_debug_keys:
             ada_discord_all_members = ada_res["approximate_member_count"]
             print("Members: ", ada_discord_all_members)
@@ -95,15 +96,14 @@ while True:
             ada_discord_all_members_online = ada_res["approximate_presence_count"]
             print("Online: ", ada_discord_all_members_online)
 
-        print("Monotonic: ", time.monotonic())
-
-        print("\nFinished!")
-        print("Next Update in %s %s" % (int(sleep_int), sleep_time_conversion))
+        print("Finished ✅")
+        print("Board Uptime: ", time_calc(time.monotonic()))
+        print("Next Update: ", time_calc(sleep_time))
         print("===============================")
-        gc.collect()
 
-    except (ValueError, RuntimeError) as e:
+    except (ConnectionError, ValueError, NameError) as e:
         print("Failed to get data, retrying\n", e)
         time.sleep(60)
         continue
     time.sleep(sleep_time)
+    

--- a/examples/requests_api_discord.py
+++ b/examples/requests_api_discord.py
@@ -29,6 +29,7 @@ pool = socketpool.SocketPool(wifi.radio)
 # 900 = 15 mins, 1800 = 30 mins, 3600 = 1 hour
 sleep_time = 900
 
+
 # Converts seconds to human readable minutes/hours/days
 def time_calc(input_time):  # input_time in seconds
     if input_time < 60:
@@ -44,6 +45,7 @@ def time_calc(input_time):  # input_time in seconds
         sleep_int = input_time / 60 / 60 / 24
         time_output = f"{sleep_int:.1f} days"
     return time_output
+
 
 discord_header = {"Authorization": "" + Discord_Auth}
 ADA_SOURCE = (
@@ -67,9 +69,7 @@ print("Connected!✅")
 
 while True:
     try:
-        print(
-            "\nAttempting to GET Discord Data!"
-        )  # --------------------------------
+        print("\nAttempting to GET Discord Data!")  # --------------------------------
         # STREAMER WARNING this will show your credentials!
         debug_request = False  # Set True to see full request
         if debug_request:
@@ -106,4 +106,3 @@ while True:
         time.sleep(60)
         continue
     time.sleep(sleep_time)
-    


### PR DESCRIPTION
One API at a time. @kattni my contributions that have _API_ in the example file name are not included in any learn guides or documentation. This is a good way to take baby steps with the update to settings.toml by first changing all of my contributions over. 

Most likely @FoamyGuy will be reviewing this one again. This is the web scrape example that requires you to get the auth key from the request header with a browser developer tool. Still works fine.

Unsure if I should embed the Web Workflow credentials for getenv in the example or just wifi?