### PR TITLE
Move socket specific code from `requests.Session` to `requests.SocketHandler`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ _build
 .idea
 .vscode
 *~
+
+# tox-specific files
+.tox


### PR DESCRIPTION
This comes from a thought and discussion to make sockets more usable and have fewer errors when connecting to multiple services (`HTTP`, `MQTT`, etc.).

I have come up with the following proposed steps:

1. Move socket specific code from `requests.Session` to `requests.SocketHandler`
   - This is the Draft PR
2. Make `requests.SocketHandler` a `singleton`
3. Add some methods for better `key<>socket` handling, and helpers like `get_open_keys()`
4. Add tests for new methods and changes
5. Make sure Docs look good
6. At this point mark this PR as `Ready for review`
7. Update `adafruit_esp32spi_socket.py` to `adafruit_esp32spi_socketpool.py`
   - Since `adafruit_esp32spi_socket.py` returns a fake `Socketpool` it would be easier to follow code with more correct naming
8. Update `Adafruit_CircuitPython_MiniMQTT` to take SocketHandler in `__init__` and use it
9. Add something like `SocketHandler.lock_socket()`
   - Which would make sure that you could always open a socket for a particular key: for example `("io.adafruit.com", 1883, "mqtt:")` so you can always connect to AdafruitIO
10. More update thoughts to come

As a side-note, I would **love** to put `SocketHandler` in it's own library, but feel that would break so many examples and things people have made...