### PR TITLE
Fix duplicate header issue

### DIFF
--- a/tests/chunk_test.py
+++ b/tests/chunk_test.py
@@ -63,7 +63,8 @@ def do_test_get_text(
     )
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
         ]
     )
@@ -105,7 +106,8 @@ def do_test_close_flush(
     )
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
         ]
     )
@@ -146,7 +148,8 @@ def do_test_get_text_extra_space(
     )
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
         ]
     )

--- a/tests/concurrent_test.py
+++ b/tests/concurrent_test.py
@@ -40,7 +40,8 @@ def test_second_connect_fails_memoryerror():  # pylint: disable=invalid-name
 
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
             mock.call(b"\r\n"),
         ]
@@ -82,7 +83,8 @@ def test_second_connect_fails_oserror():  # pylint: disable=invalid-name
 
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
             mock.call(b"\r\n"),
         ]

--- a/tests/header_test.py
+++ b/tests/header_test.py
@@ -12,7 +12,75 @@ HOST = "httpbin.org"
 RESPONSE_HEADERS = b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n"
 
 
-def test_json():
+def test_host():
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (IP, 80)),)
+    sock = mocket.Mocket(RESPONSE_HEADERS)
+    pool.socket.return_value = sock
+    sent = []
+
+    def _send(data):
+        sent.append(data)  # pylint: disable=no-member
+        return len(data)
+
+    sock.send.side_effect = _send
+
+    requests_session = adafruit_requests.Session(pool)
+    headers = {}
+    requests_session.get("http://" + HOST + "/get", headers=headers)
+
+    sock.connect.assert_called_once_with((IP, 80))
+    sent = b"".join(sent)
+    assert b"Host: httpbin.org\r\n" in sent
+
+
+def test_host_replace():
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (IP, 80)),)
+    sock = mocket.Mocket(RESPONSE_HEADERS)
+    pool.socket.return_value = sock
+    sent = []
+
+    def _send(data):
+        sent.append(data)  # pylint: disable=no-member
+        return len(data)
+
+    sock.send.side_effect = _send
+
+    requests_session = adafruit_requests.Session(pool)
+    headers = {"host": IP}
+    requests_session.get("http://" + HOST + "/get", headers=headers)
+
+    sock.connect.assert_called_once_with((IP, 80))
+    sent = b"".join(sent)
+    assert b"host: 1.2.3.4\r\n" in sent
+    assert b"Host: httpbin.org\r\n" not in sent
+    assert sent.lower().count(b"host:") == 1
+
+
+def test_user_agent():
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (IP, 80)),)
+    sock = mocket.Mocket(RESPONSE_HEADERS)
+    pool.socket.return_value = sock
+    sent = []
+
+    def _send(data):
+        sent.append(data)  # pylint: disable=no-member
+        return len(data)
+
+    sock.send.side_effect = _send
+
+    requests_session = adafruit_requests.Session(pool)
+    headers = {}
+    requests_session.get("http://" + HOST + "/get", headers=headers)
+
+    sock.connect.assert_called_once_with((IP, 80))
+    sent = b"".join(sent)
+    assert b"User-Agent: Adafruit CircuitPython\r\n" in sent
+
+
+def test_user_agent_replace():
     pool = mocket.MocketPool()
     pool.getaddrinfo.return_value = ((None, None, None, None, (IP, 80)),)
     sock = mocket.Mocket(RESPONSE_HEADERS)
@@ -30,7 +98,55 @@ def test_json():
     requests_session.get("http://" + HOST + "/get", headers=headers)
 
     sock.connect.assert_called_once_with((IP, 80))
-    sent = b"".join(sent).lower()
+    sent = b"".join(sent)
     assert b"user-agent: blinka/1.0.0\r\n" in sent
-    # The current implementation sends two user agents. Fix it, and uncomment below.
-    # assert sent.count(b"user-agent:") == 1
+    assert b"User-Agent: Adafruit CircuitPython\r\n" not in sent
+    assert sent.lower().count(b"user-agent:") == 1
+
+
+def test_content_type():
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (IP, 80)),)
+    sock = mocket.Mocket(RESPONSE_HEADERS)
+    pool.socket.return_value = sock
+    sent = []
+
+    def _send(data):
+        sent.append(data)  # pylint: disable=no-member
+        return len(data)
+
+    sock.send.side_effect = _send
+
+    requests_session = adafruit_requests.Session(pool)
+    headers = {}
+    data = {"test": True}
+    requests_session.post("http://" + HOST + "/get", data=data, headers=headers)
+
+    sock.connect.assert_called_once_with((IP, 80))
+    sent = b"".join(sent)
+    assert b"Content-Type: application/x-www-form-urlencoded\r\n" in sent
+
+
+def test_content_type_replace():
+    pool = mocket.MocketPool()
+    pool.getaddrinfo.return_value = ((None, None, None, None, (IP, 80)),)
+    sock = mocket.Mocket(RESPONSE_HEADERS)
+    pool.socket.return_value = sock
+    sent = []
+
+    def _send(data):
+        sent.append(data)  # pylint: disable=no-member
+        return len(data)
+
+    sock.send.side_effect = _send
+
+    requests_session = adafruit_requests.Session(pool)
+    headers = {"content-type": "application/test"}
+    data = {"test": True}
+    requests_session.post("http://" + HOST + "/get", data=data, headers=headers)
+
+    sock.connect.assert_called_once_with((IP, 80))
+    sent = b"".join(sent)
+    assert b"content-type: application/test\r\n" in sent
+    assert b"Content-Type: application/x-www-form-urlencoded\r\n" not in sent
+    assert sent.lower().count(b"content-type:") == 1

--- a/tests/post_test.py
+++ b/tests/post_test.py
@@ -38,7 +38,8 @@ def test_method():
     )
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"httpbin.org"),
         ]
     )
@@ -64,10 +65,18 @@ def test_form():
     pool.socket.return_value = sock
 
     requests_session = adafruit_requests.Session(pool)
-    data = {"Date": "July 25, 2019"}
+    data = {"Date": "July 25, 2019", "Time": "12:00"}
     requests_session.post("http://" + HOST + "/post", data=data)
     sock.connect.assert_called_once_with((IP, 80))
-    sock.send.assert_called_with(b"Date=July 25, 2019")
+    sock.send.assert_has_calls(
+        [
+            mock.call(b"Content-Type"),
+            mock.call(b": "),
+            mock.call(b"application/x-www-form-urlencoded"),
+            mock.call(b"\r\n"),
+        ]
+    )
+    sock.send.assert_called_with(b"Date=July 25, 2019&Time=12:00")
 
 
 def test_json():
@@ -77,7 +86,15 @@ def test_json():
     pool.socket.return_value = sock
 
     requests_session = adafruit_requests.Session(pool)
-    json_data = {"Date": "July 25, 2019"}
+    json_data = {"Date": "July 25, 2019", "Time": "12:00"}
     requests_session.post("http://" + HOST + "/post", json=json_data)
     sock.connect.assert_called_once_with((IP, 80))
-    sock.send.assert_called_with(b'{"Date": "July 25, 2019"}')
+    sock.send.assert_has_calls(
+        [
+            mock.call(b"Content-Type"),
+            mock.call(b": "),
+            mock.call(b"application/json"),
+            mock.call(b"\r\n"),
+        ]
+    )
+    sock.send.assert_called_with(b'{"Date": "July 25, 2019", "Time": "12:00"}')

--- a/tests/protocol_test.py
+++ b/tests/protocol_test.py
@@ -49,7 +49,8 @@ def test_get_https_text():
     )
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
         ]
     )
@@ -80,7 +81,8 @@ def test_get_http_text():
     )
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
         ]
     )
@@ -109,7 +111,8 @@ def test_get_close():
     )
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
         ]
     )

--- a/tests/reuse_test.py
+++ b/tests/reuse_test.py
@@ -37,7 +37,8 @@ def test_get_twice():
     )
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
         ]
     )
@@ -55,7 +56,8 @@ def test_get_twice():
     )
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
         ]
     )
@@ -85,7 +87,8 @@ def test_get_twice_after_second():
     )
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
         ]
     )
@@ -102,7 +105,8 @@ def test_get_twice_after_second():
     )
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
         ]
     )
@@ -136,7 +140,8 @@ def test_connect_out_of_memory():
     )
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
         ]
     )
@@ -153,7 +158,8 @@ def test_connect_out_of_memory():
     )
     sock3.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest2.adafruit.com"),
         ]
     )
@@ -184,7 +190,8 @@ def test_second_send_fails():
 
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
             mock.call(b"\r\n"),
         ]
@@ -222,7 +229,8 @@ def test_second_send_lies_recv_fails():  # pylint: disable=invalid-name
 
     sock.send.assert_has_calls(
         [
-            mock.call(b"Host: "),
+            mock.call(b"Host"),
+            mock.call(b": "),
             mock.call(b"wifitest.adafruit.com"),
             mock.call(b"\r\n"),
         ]


### PR DESCRIPTION
When helping a member in the discord channel `#help-with-circuitpython`, I had made the mistake of thinking that this library didn't automatically deal with turning a `dict` into a `urlencoded` string. I had them convert it by hand and try and it worked.

As it turns out - it does, but also sends the header `Content-Type: application/x-www-form-urlencoded`, which some systems (`Spotify` as one) can't handle getting the header twice.

This would fix issue https://github.com/adafruit/Adafruit_CircuitPython_Requests/issues/148

Test:
```
from os import getenv
import adafruit_requests
import socketpool
import ssl
import wifi

wifi_ssid = getenv("CIRCUITPY_WIFI_SSID")
wifi_password = getenv("CIRCUITPY_WIFI_PASSWORD")
client_id = getenv("SPOTIFY_CLIENT_ID")
client_secret = getenv("SPOTIFY_CLIENT_SECRET")

ssl_context=ssl.create_default_context()
pool = socketpool.SocketPool(wifi.radio)
wifi.radio.connect(wifi_ssid, wifi_password)

requests = adafruit_requests.Session(pool, ssl_context)

data = {"grant_type": "client_credentials", "client_id": client_id, "client_secret": client_secret}
headers = {"Content-Type": "application/x-www-form-urlencoded"}
url = "https://accounts.spotify.com/api/token"
r = requests.post(url, data=data, headers=headers)
print(r.status_code)
print(r.text)
```
Using the main branch of `Adafruit_CircuitPython_Requests`, this will return a `400` because it sends `Content-Type` twice, using this branch will succeed