### PR TITLE
close(): fix exception and enable fast-close

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -86,7 +86,9 @@ class Response:
 
     encoding = None
 
-    def __init__(self, sock: SocketType, session: "Session", fast_close: bool = False) -> None:
+    def __init__(
+        self, sock: SocketType, session: "Session", fast_close: bool = False
+    ) -> None:
         self.socket = sock
         self.encoding = "utf-8"
         self._cached = None

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -363,7 +363,7 @@ class Session:
         socket_pool: SocketpoolModuleType,
         ssl_context: Optional[SSLContextType] = None,
         session_id: Optional[str] = None,
-        fast_close: Optional[Bool] = False,
+        fast_close: Optional[bool] = False,
     ) -> None:
         self._connection_manager = get_connection_manager(socket_pool)
         self._ssl_context = ssl_context


### PR DESCRIPTION
The current code throws an exception during `close()` when it tries to convert an empty buffer (`chunk_header`).
This PR also adds an optional parameter `fast=False`. Passing `True` will skip reading.

This addresses #130 (also mentioned in #138) 