### PR TITLE
Update Fitbit API Example with Connection Manager

### DIFF
--- a/examples/wifi/expanded/requests_wifi_api_fitbit.py
+++ b/examples/wifi/expanded/requests_wifi_api_fitbit.py
@@ -8,9 +8,10 @@ import os
 import time
 
 import adafruit_connection_manager
-import adafruit_requests
 import microcontroller
 import wifi
+
+import adafruit_requests
 
 # --- Fitbit Developer Account & oAuth App Required: ---
 # Required: Google Login (Fitbit owned by Google) & Fitbit Device

--- a/examples/wifi/expanded/requests_wifi_api_fitbit.py
+++ b/examples/wifi/expanded/requests_wifi_api_fitbit.py
@@ -86,9 +86,10 @@ Refresh_Token = Fitbit_First_Refresh_Token
 top_nvm = microcontroller.nvm[0:64].decode()
 nvm_bytes = microcontroller.nvm[0:64]
 top_nvm_3bytes = nvm_bytes[0:3]
-print(f"Top NVM Length: {len(top_nvm)}")
-print(f"Top NVM: {top_nvm}")
-print(f"Top NVM bytes: {top_nvm_3bytes}")
+if DEBUG:
+    print(f"Top NVM Length: {len(top_nvm)}")
+    print(f"Top NVM: {top_nvm}")
+    print(f"Top NVM bytes: {top_nvm_3bytes}")
 if RESET_NVM:
     microcontroller.nvm[0:64] = bytearray(b"\x00" * 64)
     if top_nvm_3bytes == b"\x00\x00\x00":

--- a/examples/wifi/expanded/requests_wifi_api_fitbit.py
+++ b/examples/wifi/expanded/requests_wifi_api_fitbit.py
@@ -7,8 +7,8 @@
 import os
 import time
 
-import adafruit_connection_manager
 import microcontroller
+import adafruit_connection_manager
 import wifi
 
 import adafruit_requests
@@ -345,7 +345,7 @@ while True:
     else:
         print("🚮 NVM Cleared!")
         print(
-            "⚠️ Save your new access token & refresh token from"
+            "⚠️ Save your new access token & refresh token from "
             "Fitbits Tutorial (Step 4) to settings.toml now."
         )
         print(

--- a/examples/wifi/expanded/requests_wifi_api_fitbit.py
+++ b/examples/wifi/expanded/requests_wifi_api_fitbit.py
@@ -7,8 +7,8 @@
 import os
 import time
 
-import microcontroller
 import adafruit_connection_manager
+import microcontroller
 import wifi
 
 import adafruit_requests
@@ -210,7 +210,7 @@ while True:
                     # You can manually set this token into settings.toml
                     print(f" | Next Token: {nvmtoken.decode()}")
                     print(" | 🔑 Next token written to NVM Successfully!")
-                except (OSError) as e:
+                except OSError as e:
                     print("OS Error:", e)
                     continue
                 if DEBUG:
@@ -218,7 +218,7 @@ while True:
                     print("Scope: ", fitbit_scope)
                     print("Token Type: ", fitbit_token_type)
                     print("UserID: ", fitbit_user_id)
-            except (KeyError) as e:
+            except KeyError as e:
                 print("Key Error:", e)
                 print("Expired token, invalid permission, or (key:value) pair error.")
                 time.sleep(SLEEP_TIME)
@@ -303,7 +303,7 @@ while True:
                 else:
                     print(" | Waiting for latest sync...")
                     print(" | ❌ Not enough values for today to display yet.")
-            except (KeyError) as keyerror:
+            except KeyError as keyerror:
                 print(f"Key Error: {keyerror}")
                 print(
                     "Too Many Requests, "

--- a/examples/wifi/expanded/requests_wifi_api_fitbit.py
+++ b/examples/wifi/expanded/requests_wifi_api_fitbit.py
@@ -7,11 +7,10 @@
 import os
 import time
 
-import microcontroller
 import adafruit_connection_manager
-import wifi
-
 import adafruit_requests
+import microcontroller
+import wifi
 
 # --- Fitbit Developer Account & oAuth App Required: ---
 # Required: Google Login (Fitbit owned by Google) & Fitbit Device


### PR DESCRIPTION
Added pretty serial hierarchy view, general code cleanup and improvements, more endpoints (added Watch Battery Percentage). Attempted to ensure it meets current syntax practices. Made some constants shouty to make Pylint happy. Added a way to reset NVM back to factory default and it turned into the easiest method for anyone adding new credentials for the very first use. NVM reset is a very nice and easy to use feature now.

Serial output example:
```
📡 Connecting to WiFi...
✅ WiFi!
 | MANUAL REBOOT TOKEN DIFFERENCE -------
 | Requesting authorization for next token
 | Next Token: b768b6a28dd890d123e83e86669f5b8913647946b1736f2b3577ee8baef420a6
 | 🔑 Next token written to NVM Successfully!
 | Attempting to GET Fitbit JSON!
 | ✅ Fitbit Intraday JSON!
 |  | Fitbit Date: 2024-03-17
 |  | Fitbit Time: 11:41
 |  | Today's Logged Pulses: 702
 |  | Latest 15 Minute Averages: 71, 66, 69, 68, 67, 69, 67, 70, 68, 69, 69, 69, 68, 69, 69
 | Attempting to GET Device JSON!
 | ✅ Fitbit Device JSON!
 |  | Watch Battery %: 30

Finished!
Board Uptime: 3.1 days
Next Update: 15 minutes
===============================
```

NVM Reset Serial output example:
```
TOP NVM IS BRAND NEW! WAITING FOR A FIRST TOKEN
Top NVM RESET:
Refresh Token Reset:
🚮 NVM Cleared!
⚠️ Save your new access token & refresh token from Fitbits Tutorial (Step 4) to settings.toml now.
⚠️ If the script runs again(due to settings.toml file save) while reset=True that's ok!
⚠️ Then set RESET_NVM back to False.
```