### PR TITLE
update wifi_simpletest with Connection Manager

### DIFF
--- a/examples/wifi/requests_wifi_simpletest.py
+++ b/examples/wifi/requests_wifi_simpletest.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
+# Updated for Circuit Python 9.0
+""" WiFi Simpletest """
+# pylint: disable=import-error
 
 import os
-import ssl
 
-import socketpool
+import adafruit_connection_manager
 import wifi
 
 import adafruit_requests
@@ -13,60 +15,57 @@ import adafruit_requests
 ssid = os.getenv("CIRCUITPY_WIFI_SSID")
 password = os.getenv("CIRCUITPY_WIFI_PASSWORD")
 
-# Initialize WiFi Pool (There can be only 1 pool & top of script)
-radio = wifi.radio
-pool = socketpool.SocketPool(radio)
-
-print("Connecting to AP...")
-while not wifi.radio.ipv4_address:
-    try:
-        wifi.radio.connect(ssid, password)
-    except ConnectionError as e:
-        print("could not connect to AP, retrying: ", e)
-print("Connected to", str(radio.ap_info.ssid, "utf-8"), "\tRSSI:", radio.ap_info.rssi)
-
-# Initialize a requests session
-ssl_context = ssl.create_default_context()
-requests = adafruit_requests.Session(pool, ssl_context)
-
 TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
 JSON_GET_URL = "https://httpbin.org/get"
 JSON_POST_URL = "https://httpbin.org/post"
 
-print("Fetching text from %s" % TEXT_URL)
+# Initalize Wifi, Socket Pool, Request Session
+pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
+requests = adafruit_requests.Session(pool, ssl_context)
+rssi = wifi.radio.ap_info.rssi
+
+print(f"\nConnecting to {ssid}...")
+print(f"Signal Strength: {rssi}")
+try:
+    # Connect to the Wi-Fi network
+    wifi.radio.connect(ssid, password)
+except OSError as e:
+    print(f"❌ OSError: {e}")
+print("✅ Wifi!")
+
+print(f" | GET Text Test: {TEXT_URL}")
 response = requests.get(TEXT_URL)
-print("-" * 40)
-
-print("Text Response: ", response.text)
-print("-" * 40)
+print(f" | ✅ GET Response: {response.text}")
 response.close()
+print(f" | ✂️ Disconnected from {TEXT_URL}")
+print("-" * 80)
 
-print("Fetching JSON data from %s" % JSON_GET_URL)
+print(f" | GET Full Response Test: {JSON_GET_URL}")
 response = requests.get(JSON_GET_URL)
-print("-" * 40)
-
-print("JSON Response: ", response.json())
-print("-" * 40)
+print(f" | ✅ Unparsed Full JSON Response: {response.json()}")
 response.close()
+print(f" | ✂️ Disconnected from {JSON_GET_URL}")
+print("-" * 80)
 
-data = "31F"
-print("POSTing data to {0}: {1}".format(JSON_POST_URL, data))
-response = requests.post(JSON_POST_URL, data=data)
-print("-" * 40)
-
+DATA = "This is an example of a JSON value"
+print(f" | ✅ JSON 'value' POST Test: {JSON_POST_URL} {DATA}")
+response = requests.post(JSON_POST_URL, data=DATA)
 json_resp = response.json()
 # Parse out the 'data' key from json_resp dict.
-print("Data received from server:", json_resp["data"])
-print("-" * 40)
+print(f" | ✅ JSON 'value' Response: {json_resp['data']}")
 response.close()
+print(f" | ✂️ Disconnected from {JSON_POST_URL}")
+print("-" * 80)
 
-json_data = {"Date": "July 25, 2019"}
-print("POSTing data to {0}: {1}".format(JSON_POST_URL, json_data))
+json_data = {"Date": "January 1, 1970"}
+print(f" | ✅ JSON 'key':'value' POST Test: {JSON_POST_URL} {json_data}")
 response = requests.post(JSON_POST_URL, json=json_data)
-print("-" * 40)
-
 json_resp = response.json()
 # Parse out the 'json' key from json_resp dict.
-print("JSON Data received from server:", json_resp["json"])
-print("-" * 40)
+print(f" | ✅ JSON 'key':'value' Response: {json_resp['json']}")
 response.close()
+print(f" | ✂️ Disconnected from {JSON_POST_URL}")
+print("-" * 80)
+
+print("Finished!")

--- a/examples/wifi/requests_wifi_simpletest.py
+++ b/examples/wifi/requests_wifi_simpletest.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 # Updated for Circuit Python 9.0
 """ WiFi Simpletest """
-# pylint: disable=import-error
 
 import os
 


### PR DESCRIPTION
Updating wifi_simpletest to 9.0 with Connection Manager

Added
- uses f-strings for formatting
- pretty serial hierarchy view with emojis (for IDE's that support them)
- general code cleanup and improvements
- shouty constants to make Pylint happy.
- imports sorted
- uses settings.toml by default
- using Connection Manager by default

Serial output example:
```
Connecting to WiFi...
Signal Strength: -58
✅ Wifi!
 | GET Text Test: http://wifitest.adafruit.com/testwifi/index.html
 | ✅ GET Response: This is a test of Adafruit WiFi!
If you can read this, its working :)
 | ✂️ Disconnected from http://wifitest.adafruit.com/testwifi/index.html
--------------------------------------------------------------------------------
 | GET Full Response Test: https://httpbin.org/get
 | ✅ Unparsed Full JSON Response: {'url': 'https://httpbin.org/get', 'headers': {'User-Agent': 'Adafruit CircuitPython', 'Host': 'httpbin.org', 'X-Amzn-Trace-Id': 'Root=1-62613a2a-1106178859bf4e2318675309'}, 'args': {}, 'origin': 'xxx.xxx.xxx.xxx'}
 | ✂️ Disconnected from https://httpbin.org/get
--------------------------------------------------------------------------------
 | ✅ JSON 'value' POST Test: https://httpbin.org/post This is an example of a JSON value
 | ✅ JSON 'value' Response: This is an example of a JSON value
 | ✂️ Disconnected from https://httpbin.org/post
--------------------------------------------------------------------------------
 | ✅ JSON 'key':'value' POST Test: https://httpbin.org/post {'Date': 'January 1, 1970'}
 | ✅ JSON 'Key':'Value' Response: {'Date': 'January 1, 1970'}
 | ✂️ Disconnected from https://httpbin.org/post
--------------------------------------------------------------------------------
Finished!
```