### PR TITLE
Convert CRLF line ending to LF

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: 2020 Scott Shawcroft for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
-
 """
 `adafruit_requests`
 ================================================================================


### PR DESCRIPTION
This file has 608 line endings in CRLF format instead of LF format and is making my local pre-commit throw about 600 errors.  Because there's no actual line changes it won't allow me to submit without changing a line.  So deleted a blank line . Can then commit to force the file to switch from CRLF to LF... hopefully.  

I used Notepad++ with EOL symbols visible to ensure the switch from CRLF to LF.  The only way it might stay as CRLF is if my Github desktop converts them back to CRLF (which is possible).  This commit is an attempt to fix pre-commit errors.

![Capture](https://github.com/adafruit/Adafruit_CircuitPython_Requests/assets/49322231/7d5bf29f-74da-452b-93ae-cb723f022397)

The only change in this commit is to convert invisible line endings to LF and 1 deleted blank line.