### PR TITLE
add Queue-Times API Example

### DIFF
--- a/examples/wifi/expanded/requests_wifi_api_queuetimes.py
+++ b/examples/wifi/expanded/requests_wifi_api_queuetimes.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2024 DJDevon3
+# SPDX-License-Identifier: MIT
+# Coded for Circuit Python 9.x
+"""Queue-Times.com API w/Display Example"""
+
+import os
+import time
+
+import adafruit_connection_manager
+import wifi
+
+import adafruit_requests
+
+# Initalize Wifi, Socket Pool, Request Session
+pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
+requests = adafruit_requests.Session(pool, ssl_context)
+
+# Time between API refreshes
+# 900 = 15 mins, 1800 = 30 mins, 3600 = 1 hour
+SLEEP_TIME = 300
+
+# Get WiFi details, ensure these are setup in settings.toml
+ssid = os.getenv("CIRCUITPY_WIFI_SSID")
+password = os.getenv("CIRCUITPY_WIFI_PASSWORD")
+
+# Publicly Open API (no credentials required)
+QTIMES_SOURCE = "https://queue-times.com/parks/16/queue_times.json"
+
+
+def time_calc(input_time):
+    """Converts seconds to minutes/hours/days"""
+    if input_time < 60:
+        return f"{input_time:.0f} seconds"
+    if input_time < 3600:
+        return f"{input_time / 60:.0f} minutes"
+    if input_time < 86400:
+        return f"{input_time / 60 / 60:.0f} hours"
+    return f"{input_time / 60 / 60 / 24:.1f} days"
+
+
+qtimes_json = {}
+while True:
+    now = time.monotonic()
+    # Connect to Wi-Fi
+    print("\n===============================")
+    print("Connecting to WiFi...")
+    while not wifi.radio.ipv4_address:
+        try:
+            wifi.radio.connect(ssid, password)
+        except ConnectionError as e:
+            print("❌ Connection Error:", e)
+            print("Retrying in 10 seconds")
+    print("✅ WiFi!")
+
+    try:
+        print(" | Attempting to GET Queue-Times JSON!")
+        try:
+            qtimes_response = requests.get(url=QTIMES_SOURCE)
+            qtimes_json = qtimes_response.json()
+        except ConnectionError as e:
+            print("Connection Error:", e)
+            print("Retrying in 10 seconds")
+        print(" | ✅ Queue-Times JSON!")
+
+        DEBUG_QTIMES = False
+        if DEBUG_QTIMES:
+            print("Full API GET URL: ", QTIMES_SOURCE)
+            print(qtimes_json)
+        qtimes_response.close()
+        print("✂️ Disconnected from Queue-Times API")
+
+        print("\nFinished!")
+        print(f"Board Uptime: {time_calc(time.monotonic())}")
+        print(f"Next Update: {time_calc(SLEEP_TIME)}")
+        print("===============================")
+    except (ValueError, RuntimeError) as e:
+        print("Failed to get data, retrying\n", e)
+        time.sleep(60)
+        break
+
+    # Loop infinitely until its time to re-poll
+    if time.monotonic() - now <= SLEEP_TIME:
+        for land in qtimes_json["lands"]:
+            qtimes_lands = str(land["name"])
+            print(f" |  | Lands: {qtimes_lands}")
+            time.sleep(1)
+
+            # Loop through each ride in the land
+            for ride in land["rides"]:
+                qtimes_rides = str(ride["name"])
+                qtimes_queuetime = str(ride["wait_time"])
+                qtimes_isopen = str(ride["is_open"])
+
+                print(f" |  | Rides: {qtimes_rides}")
+                print(f" |  | Queue Time: {qtimes_queuetime} Minutes")
+                if qtimes_isopen == "False":
+                    print(" |  | Status: Closed")
+                elif qtimes_isopen == "True":
+                    print(" |  | Status: Open")
+                else:
+                    print(" |  | Status: Unknown")
+
+                time.sleep(1)  # delay between list items
+    else:  # When its time to poll, break to top of while True loop.
+        break

--- a/examples/wifi/expanded/requests_wifi_api_queuetimes.py
+++ b/examples/wifi/expanded/requests_wifi_api_queuetimes.py
@@ -4,7 +4,6 @@
 """Queue-Times.com API Example"""
 
 import os
-import time
 
 import adafruit_connection_manager
 import wifi
@@ -55,34 +54,33 @@ print("✅ WiFi!")
 try:
     with requests.get(url=QTIMES_SOURCE) as qtimes_response:
         qtimes_json = qtimes_response.json()
+
+    print(" | ✅ Queue-Times JSON\n")
+    DEBUG_QTIMES = False
+    if DEBUG_QTIMES:
+        print("Full API GET URL: ", QTIMES_SOURCE)
+        print(qtimes_json)
+
+    # Poll Once and end script
+    for land in qtimes_json["lands"]:
+        qtimes_lands = str(land["name"])
+        print(f" |  Land: {qtimes_lands}")
+
+        # Loop through each ride in the land
+        for ride in land["rides"]:
+            qtimes_rides = str(ride["name"])
+            qtimes_queuetime = str(ride["wait_time"])
+            qtimes_isopen = str(ride["is_open"])
+
+            print(f" |  | Ride: {qtimes_rides}")
+            print(f" |  | Queue Time: {qtimes_queuetime} Minutes")
+            if qtimes_isopen == "False":
+                print(" |  | Status: Closed\n")
+            elif qtimes_isopen == "True":
+                print(" |  | Status: Open\n")
+            else:
+                print(" |  | Status: Unknown\n")
+
+
 except ConnectionError as e:
     print("Connection Error:", e)
-print(" | ✅ Queue-Times JSON\n")
-DEBUG_QTIMES = False
-if DEBUG_QTIMES:
-    print("Full API GET URL: ", QTIMES_SOURCE)
-    print(qtimes_json)
-qtimes_response.close()
-
-# Poll Once and end script
-for land in qtimes_json["lands"]:
-    qtimes_lands = str(land["name"])
-    print(f" |  Land: {qtimes_lands}")
-    time.sleep(1)
-
-    # Loop through each ride in the land
-    for ride in land["rides"]:
-        qtimes_rides = str(ride["name"])
-        qtimes_queuetime = str(ride["wait_time"])
-        qtimes_isopen = str(ride["is_open"])
-
-        print(f" |  | Ride: {qtimes_rides}")
-        print(f" |  | Queue Time: {qtimes_queuetime} Minutes")
-        if qtimes_isopen == "False":
-            print(" |  | Status: Closed\n")
-        elif qtimes_isopen == "True":
-            print(" |  | Status: Open\n")
-        else:
-            print(" |  | Status: Unknown\n")
-
-        time.sleep(1)  # delay between list items

--- a/examples/wifi/expanded/requests_wifi_api_queuetimes.py
+++ b/examples/wifi/expanded/requests_wifi_api_queuetimes.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 DJDevon3
 # SPDX-License-Identifier: MIT
 # Coded for Circuit Python 9.x
-"""Queue-Times.com API w/Display Example"""
+"""Queue-Times.com API Example"""
 
 import os
 import time
@@ -92,7 +92,7 @@ while True:
                 qtimes_queuetime = str(ride["wait_time"])
                 qtimes_isopen = str(ride["is_open"])
 
-                print(f" |  | Rides: {qtimes_rides}")
+                print(f" |  | Ride: {qtimes_rides}")
                 print(f" |  | Queue Time: {qtimes_queuetime} Minutes")
                 if qtimes_isopen == "False":
                     print(" |  | Status: Closed")


### PR DESCRIPTION
Used for Disney theme park queue times. Public API.  Runs infinitely until time to update.  The way this one works is slightly different from most examples.  It's designed for a small display to take to the theme park and get updates on queue times.  

Here's an [example on a display](https://github.com/DJDevon3/My_Circuit_Python_Projects/tree/main/Boards/espressif/Unexpected%20Maker%20Feather%20S3/4.0%20ST7796S/QueueTimes%20API%20Display).

Inspired by Reddit user [Fishing_Quiet asked for help getting this API working on a display](https://www.reddit.com/r/circuitpython/comments/1bkpynl/updating_json_file/).