### PR TITLE
add context manager vs explicit close() example

### DIFF
--- a/examples/wifi/requests_wifi_context_manager_basics.py
+++ b/examples/wifi/requests_wifi_context_manager_basics.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2024 DJDevon3
+# SPDX-License-Identifier: MIT
+# Updated for Circuit Python 9.0
+""" WiFi Context Manager Basics Example """
+
+import os
+
+import adafruit_connection_manager
+import wifi
+
+import adafruit_requests
+
+# Get WiFi details, ensure these are setup in settings.toml
+ssid = os.getenv("CIRCUITPY_WIFI_SSID")
+password = os.getenv("CIRCUITPY_WIFI_PASSWORD")
+
+# Initalize Wifi, Socket Pool, Request Session
+pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
+requests = adafruit_requests.Session(pool, ssl_context)
+rssi = wifi.radio.ap_info.rssi
+
+JSON_GET_URL = "https://httpbin.org/get"
+
+print(f"\nConnecting to {ssid}...")
+print(f"Signal Strength: {rssi}")
+try:
+    # Connect to the Wi-Fi network
+    wifi.radio.connect(ssid, password)
+except OSError as e:
+    print(f"❌ OSError: {e}")
+print("✅ Wifi!\n")
+
+print("-" * 40)
+# This method requires an explicit close
+print("Explicit Close Example")
+response = requests.get(JSON_GET_URL)
+json_data = response.json()
+if response.status_code == 200:
+    print(f" | 🆗 Status Code: {response.status_code}")
+else:
+    print(f" |  | Status Code: {response.status_code}")
+headers = json_data["headers"]
+date = response.headers.get("date", "")
+print(f" |  | Response Timestamp: {date}")
+
+# Close socket manually (prone to mid-disconnect socket errors, out of retries)
+response.close()
+print(f" | ✂️ Disconnected from {JSON_GET_URL}")
+
+# Buffer data is still available from json_data after socket close
+content_type = response.headers.get("content-type", "")
+print(f" |  Content-Type: {content_type}")
+
+print("\nversus\n")
+
+print("-" * 40)
+# Closing socket is included automatically using "with"
+print("Context Manager WITH Example")
+response = requests.get(JSON_GET_URL)
+# Wrap a request using a with statement
+with requests.get(JSON_GET_URL) as response:
+    date = response.headers.get("date", "")
+    json_data = response.json()
+    if response.status_code == 200:
+        print(f" | 🆗 Status Code: {response.status_code}")
+    else:
+        print(f" |  | Status Code: {response.status_code}")
+    headers = json_data["headers"]
+    print(f" |  | Response Timestamp: {date}")
+
+# Notice there is no response.close()
+# It's handled automatically in a with statement
+# This is the better way.
+print(f" | ✂️ Disconnected from {JSON_GET_URL}")
+
+# JSON data still available outside of with.
+content_type = response.headers.get("content-type", "")
+print(f" |  Content-Type: {content_type}")
+
+
+print("\nBoth examples are functionally identical")
+print(
+    "However, a with statement is more robust against disconnections mid-request "
+    + "and automatically closes the socket."
+)
+print("Using with statements for requests is recommended\n\n")


### PR DESCRIPTION
This should be handy to point beginners at for recommended syntax to use with API requests. This was discussed in this weeks meeting.  Before I proceed to update all examples to use `with` I'd like to add an example that covers why it's a better way to go.  Instead of explaining to a beginner, can point them at this script so they can run it and see the code comments for themselves that details the process.  If you have any wording or syntax changes to improve it feedback always appreciated!