### PR TITLE
handle servers that omit a space after a colon in response headers

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -251,7 +251,8 @@ class Response:
             header = self._readto(b"\r\n")
             if not header:
                 break
-            title, content = bytes(header).split(b": ", 1)
+            title, content = bytes(header).split(b":", 1)
+            content = content.strip()
             if title and content:
                 # enforce that all headers are lowercase
                 title = str(title, "utf-8").lower()


### PR DESCRIPTION
Example URL: "http://ice2.somafm.com/dronezone-128-mp3"

```
$ curl -i http://ice2.somafm.com/dronezone-128-mp3
HTTP/1.1 200 OK
Content-Type: audio/mpeg
Date: Wed, 03 Jul 2024 21:17:04 GMT
icy-br:128
...
```