### PR TITLE
Fixes for exceptions in Session.request leading to sockets not properly closed

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -648,8 +648,8 @@ class Session:
                 # Read the H of "HTTP/1.1" to make sure the socket is alive. send can appear to work
                 # even when the socket is closed.
                 # Both recv/recv_into can raise OSError; when that happens, we need to call
-                # _connection_manager.close_socket(socket) or future calls to _connection_manager.get_socket()
-                # for the same parameter set will fail
+                # _connection_manager.close_socket(socket) or future calls to
+                # _connection_manager.get_socket() for the same parameter set will fail
                 try:
                     if hasattr(socket, "recv"):
                         result = socket.recv(1)


### PR DESCRIPTION
Fix cases in Session.request method where an exception could lead to exiting the method without the created socket being owned by a response or closed.  This would then cause future calls to get a socket with the same parameters to fail because one already existed and hadn't been closed.  The PR https://github.com/adafruit/Adafruit_CircuitPython_Requests/pull/72 fixed this issue for one case where an exception could be raised. This generalizes that in an attempt to fix it in other cases that could still be hit.