### PR TITLE
update examples to use ap_info

### DIFF
--- a/examples/esp32spi/requests_esp32spi_advanced.py
+++ b/examples/esp32spi/requests_esp32spi_advanced.py
@@ -40,7 +40,7 @@ while not radio.is_connected:
     except RuntimeError as e:
         print("could not connect to AP, retrying: ", e)
         continue
-print("Connected to", str(radio.ssid, "utf-8"), "\tRSSI:", radio.rssi)
+print("Connected to", str(radio.ap_info.ssid, "utf-8"), "\tRSSI:", radio.ap_info.rssi)
 
 # Initialize a requests session
 pool = adafruit_connection_manager.get_radio_socketpool(radio)

--- a/examples/esp32spi/requests_esp32spi_simpletest.py
+++ b/examples/esp32spi/requests_esp32spi_simpletest.py
@@ -40,7 +40,7 @@ while not radio.is_connected:
     except RuntimeError as e:
         print("could not connect to AP, retrying: ", e)
         continue
-print("Connected to", str(radio.ssid, "utf-8"), "\tRSSI:", radio.rssi)
+print("Connected to", str(radio.ap_info.ssid, "utf-8"), "\tRSSI:", radio.ap_info.rssi)
 
 # Initialize a requests session
 pool = adafruit_connection_manager.get_radio_socketpool(radio)


### PR DESCRIPTION
Now need to use `.ap_info.rssi` and `.ap_info.ssid` instead of just `.rssi` and `.ssid`.

Tested on a Matrix Portal M4.

At least one of these examples is used in a Guide page.