### PR TITLE
add port back to host arguments (sends correct host-header, fixes redirects)

### DIFF
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -647,7 +647,9 @@ class Session:
             )
             ok = True
             try:
-                self._send_request(socket, f"{host}:{port}", method, path, headers, data, json, files)
+                self._send_request(
+                    socket, f"{host}:{port}", method, path, headers, data, json, files
+                )
             except OSError as exc:
                 last_exc = exc
                 ok = False

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -620,8 +620,10 @@ class Session:
             raise ValueError("Unsupported protocol: " + proto)
 
         if ":" in host:
-            host, port = host.split(":", 1)
+            host_only, port = host.split(":", 1)
             port = int(port)
+        else:
+            host_only = host
 
         if self._last_response:
             self._last_response.close()
@@ -638,7 +640,7 @@ class Session:
         while retry_count < 2:
             retry_count += 1
             socket = self._connection_manager.get_socket(
-                host,
+                host_only,
                 port,
                 proto,
                 session_id=self._session_id,
@@ -647,9 +649,7 @@ class Session:
             )
             ok = True
             try:
-                self._send_request(
-                    socket, f"{host}:{port}", method, path, headers, data, json, files
-                )
+                self._send_request(socket, host, method, path, headers, data, json, files)
             except OSError as exc:
                 last_exc = exc
                 ok = False
@@ -690,7 +690,7 @@ class Session:
                     url = redirect
                 elif redirect[0] == "/":
                     # relative URL, absolute path
-                    url = "/".join([proto, dummy, f"{host}:{port}", redirect[1:]])
+                    url = "/".join([proto, dummy, host, redirect[1:]])
                 else:
                     # relative URL, relative path
                     path = path.rsplit("/", 1)[0]
@@ -699,7 +699,7 @@ class Session:
                         path = path.rsplit("/", 1)[0]
                         redirect = redirect.split("../", 1)[1]
 
-                    url = "/".join([proto, dummy, f"{host}:{port}", path, redirect])
+                    url = "/".join([proto, dummy, host, path, redirect])
 
                 self._last_response = resp
                 resp = self.request(method, url, data, json, headers, stream, timeout)

--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -647,7 +647,7 @@ class Session:
             )
             ok = True
             try:
-                self._send_request(socket, host, method, path, headers, data, json, files)
+                self._send_request(socket, f"{host}:{port}", method, path, headers, data, json, files)
             except OSError as exc:
                 last_exc = exc
                 ok = False
@@ -688,7 +688,7 @@ class Session:
                     url = redirect
                 elif redirect[0] == "/":
                     # relative URL, absolute path
-                    url = "/".join([proto, dummy, host, redirect[1:]])
+                    url = "/".join([proto, dummy, f"{host}:{port}", redirect[1:]])
                 else:
                     # relative URL, relative path
                     path = path.rsplit("/", 1)[0]
@@ -697,7 +697,7 @@ class Session:
                         path = path.rsplit("/", 1)[0]
                         redirect = redirect.split("../", 1)[1]
 
-                    url = "/".join([proto, dummy, host, path, redirect])
+                    url = "/".join([proto, dummy, f"{host}:{port}", path, redirect])
 
                 self._last_response = resp
                 resp = self.request(method, url, data, json, headers, stream, timeout)


### PR DESCRIPTION
The current version of `request()` strips the  port from the host-part of the  url. Subsequently, `_send_request()` sends a wrong host-header. Also when relative redirects are processed, the missing original port will redirect to a wrong url.